### PR TITLE
Explicitly JScript

### DIFF
--- a/launcher/1.1.1/update.py
+++ b/launcher/1.1.1/update.py
@@ -286,7 +286,7 @@ def create_desktop_shortcut():
         #    return
 
         import subprocess
-        p = subprocess.call(["Wscript.exe", "create_shortcut.js"], shell=False)
+        p = subprocess.call(["Wscript.exe", "//E:JScript", "create_shortcut.js"], shell=False)
 
 def notify_install_tcpz_for_winXp():
     import ctypes


### PR DESCRIPTION
避免遇到【没有文件扩展“.js”的脚本引擎。】错误。
在 `HKEY_CLASSES_ROOT\.js` 的默认值非 `JSFile` 的情况下也能正常运行。

见 `wscript /?`
未添加 //B 忽略错误，以获得更多错误情况（若有）。
建议未来用Python实现（需要研究API）。