### PR TITLE
Update uploader.py

### DIFF
--- a/goagent/3.1.48/server/uploader.py
+++ b/goagent/3.1.48/server/uploader.py
@@ -6,6 +6,9 @@ import os
 import re
 import socket
 import time
+import ssl
+
+ssl._create_default_https_context = ssl._create_unverified_context
 
 code_path = os.path.dirname(os.path.abspath(__file__))
 os.chdir(code_path)


### PR DESCRIPTION
解决在Archlinux下上传会遇到的错误：
upload  fail: \<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:581)>
来自：
https://code.google.com/p/goagent/issues/detail?id=19742&can=1&q=SSL%3A%20CERTIFICATE_VERIFY_FAILED&colspec=ID%20Opened%20Reporter%20Modified%20Summary%20Stars