### PR TITLE
Refine the HTML and CSS.

### DIFF
--- a/launcher/1.4.0/web_ui/config.html
+++ b/launcher/1.4.0/web_ui/config.html
@@ -26,7 +26,9 @@
     </div> <!-- .row-fluid -->
     <div class="row-fluid">
         <div class="span4">
-            <label for="module-switch" style="font-weight: bold;"><i class="icon icon-chevron-right"></i> 模块开关(重启生效)</label>
+            <label for="module-switch">
+                <i class="icon icon-chevron-right"></i> 模块开关(重启生效)
+            </label>
         </div> <!-- .span4 -->
     </div> <!-- .row-fluid -->
     <div id="module-switch" style="display: none;">

--- a/launcher/1.4.0/web_ui/css/style.css
+++ b/launcher/1.4.0/web_ui/css/style.css
@@ -91,11 +91,10 @@ div#content form div.row-fluid {
     margin-bottom: 10px;
 }
 
-div#content form div.row-fluid > div.span4 > label {
+div#content div.row-fluid > div.span4 > label {
     font-weight: bold;
     margin: 10px 0 0;
 }
-
 
 div#content form div.row-fluid > div.span4 > label > a {
     font-weight: normal;
@@ -109,8 +108,8 @@ div#content input[type=password] {
             box-sizing: border-box;
 }
 
-/* Style for config.html in GoAgent */
-div#content form#goagent-config div#advanced-options {
+div#content div#advanced-options,
+div#content div#module-switch {
     padding-left: 20px;
 }
 


### PR DESCRIPTION
## Change Log
把HTML中的`style`标签合并到CSS中, 尽量不要在HTML中使用`style`标签.
例外: `style="display: none;"` 这是因为JavaScript中的`slideUp()`和`slideDown()`函数的原理是修改style中的这个属性, 写到CSS中就会变得不太直观.