### PR TITLE
当GoAgent或PHP代理状态改变时自动刷新系统设置页面

### DIFF
--- a/goagent/3.1.49/web_ui/config.html
+++ b/goagent/3.1.49/web_ui/config.html
@@ -181,10 +181,10 @@
                 $('#proxy-password').val(result['proxy_passwd']);
             },
             error: function(){
-                    $('.alert').html('读取设置失败。');
-                    $('.alert').addClass('alert-error');
-                    $('.alert').removeClass('alert-success');
-                    $('.alert').removeClass('hide');
+                $('.alert').html('读取设置失败.');
+                $('.alert').addClass('alert-error');
+                $('.alert').removeClass('alert-success');
+                $('.alert').removeClass('hide');
             }
         });     
     });

--- a/goagent/3.1.49/web_ui/status.html
+++ b/goagent/3.1.49/web_ui/status.html
@@ -5,9 +5,8 @@
     我们建议您使用最新版本的Chrome浏览器。
 </div>
 <![endif]-->
-<div class="alert hide" id="alert-box">
+<div id="alert-box" class="alert alert-warning hide"></div>
 
-</div>
 <table id="status" class="table table-bordered table-striped">
     <thead>
         <tr>
@@ -160,18 +159,22 @@
                 $('#ip-connect-interval').html(result['ip_connect_interval']);
                 $('#block-stat').html(result['block_stat']);
 
-                if(!$('#alert-box').hasClass("hide")){
+                if ( !$('#alert-box').hasClass("hide") ) {
                     $('#alert-box').addClass("hide");
                 }
             },
             error: function(result) {
-                form_val = $('#sys-platform').html();
-                if(form_val == ""){
-                    $('#alert-box').html('状态页显示空白，很可能GoAgent启动失败，请按<a href="https://github.com/XX-net/XX-Net/wiki/How-to-get-start-error-log" target="_blank">指引</a>查找问题原因。<br>');
-                }else{
-                    $('#alert-box').html('GoAgent进程无响应，可能已退出。');
+                var formValue = $('#sys-platform').html();
+                if ( formValue == '' ) {
+                    $('#alert-box').html('状态页显示空白, 很可能GoAgent启动失败, 请按<a href="https://github.com/XX-net/XX-Net/wiki/How-to-get-start-error-log" target="_blank">指引</a>查找问题原因.<br>');
+                } else {
+                    $('#alert-box').html('GoAgent进程无响应, 可能已退出.');
                 }
-                $('#alert-box').removeClass("hide");
+
+                $('html, body').animate({
+                    scrollTop:0
+                }, 'slow');
+                $('#alert-box').removeClass('hide');
             }
         });
     }

--- a/launcher/1.4.0/web_ui/config.html
+++ b/launcher/1.4.0/web_ui/config.html
@@ -26,25 +26,25 @@
     </div> <!-- .row-fluid -->
     <div class="row-fluid">
         <div class="span4">
-            <label for="module-switch">
-                <i class="icon icon-chevron-right"></i> 模块开关
+            <label for="advanced-options">
+                <i class="icon icon-chevron-right"></i> 高级选项
             </label>
         </div> <!-- .span4 -->
     </div> <!-- .row-fluid -->
-    <div id="module-switch" style="display: none;">
+    <div id="advanced-options" style="display: none;">
         <div class="row-fluid">
-            <div class="span4">Goagent模块开关</div> <!-- .span4 -->
+            <div class="span4">启用Goagent</div> <!-- .span4 -->
             <div class="span8">
                 <input id="goagent-enable" type="checkbox" data-toggle="switch" />
             </div> <!-- .span8 -->
         </div> <!-- .row-fluid -->
         <div class="row-fluid">
-            <div class="span4">PHP模块开关</div> <!-- .span4 -->
+            <div class="span4">启用PHP代理</div> <!-- .span4 -->
             <div class="span8">
                 <input id="php-enable" type="checkbox" data-toggle="switch" />
             </div> <!-- .span8 -->
         </div> <!-- .row-fluid -->
-    </div> <!-- #module-switch -->
+    </div> <!-- #advanced-options -->
 </div> <!-- #options -->
 
 <!-- JavaScript -->
@@ -55,6 +55,11 @@
 </script>
 <script type="text/javascript">
     $(function() {
+        getStatus();
+    });
+</script>
+<script type="text/javascript">
+    function getStatus() {
         var pageRequests = {
             'cmd': 'get_config'
         };
@@ -83,34 +88,37 @@
 
                     $( "#popup-webui").prop('checked', true);
                 }
-                if ( result['php_enable'] != 0 ) {
-                    $( "#php-enable").parent().removeClass('switch-off');
-                    $( "#php-enable").parent().addClass('switch-on');
-
-                    $( "#php-enable").prop('checked', true);
-                }
                 if ( result['goagent_enable'] != 0 ) {
                     $( "#goagent-enable").parent().removeClass('switch-off');
                     $( "#goagent-enable").parent().addClass('switch-on');
 
                     $( "#goagent-enable").prop('checked', true);
                 }
+                if ( result['php_enable'] != 0 ) {
+                    $( "#php-enable").parent().removeClass('switch-off');
+                    $( "#php-enable").parent().addClass('switch-on');
+
+                    $( "#php-enable").prop('checked', true);
+                }
+            },
+            error: function() {
+                displayErrorMessage();
             }
-        });     
-    });
+        });
+    }
 </script>
 <script type="text/javascript">
-    $('label[for=module-switch]').click(function() {
-        var isAdvancedOptionsShown = $('#module-switch').is(':visible');
+    $('label[for=advanced-options]').click(function() {
+        var isAdvancedOptionsShown = $('#advanced-options').is(':visible');
 
         if ( !isAdvancedOptionsShown ) {
             $('i.icon', this).removeClass('icon-chevron-right');
             $('i.icon', this).addClass('icon-chevron-down');
-            $('#module-switch').slideDown();            
+            $('#advanced-options').slideDown();            
         } else {
             $('i.icon', this).removeClass('icon-chevron-down');
             $('i.icon', this).addClass('icon-chevron-right');
-            $('#module-switch').slideUp();
+            $('#advanced-options').slideUp();
         }
     });
 </script>
@@ -139,20 +147,20 @@
         return setConfig(key, value);
     });
 
-    $('#php-enable').change(function() {
-        var isChecked = $(this).is(':checked'),
-            key       = 'php_enable',
-            value     = isChecked ? 1 : 0;
-
-        return setConfig(key, value);
-    });
-
     $('#goagent-enable').change(function() {
         var isChecked = $(this).is(':checked'),
             key       = 'goagent_enable',
             value     = isChecked ? 1 : 0;
 
-        return setConfig(key, value);
+        setConfig(key, value);
+    });
+
+    $('#php-enable').change(function() {
+        var isChecked = $(this).is(':checked'),
+            key       = 'php_enable',
+            value     = isChecked ? 1 : 0;
+
+        setConfig(key, value);
     });
 </script>
 <script type="text/javascript">
@@ -169,17 +177,54 @@
             dataType: 'JSON',
             success: function(result) {
                 if ( result['res'] == 'success' ) {
-                    $('.alert').html('设置已成功保存.');
-                    $('.alert').addClass('alert-success');
+                    if ( key == 'goagent_enable' || key == 'php_enable' ) {
+                        restatingService(key);
+                        $('.alert').addClass('alert-warning');
+                        $('.alert').removeClass('alert-success');
+                    } else {
+                        $('.message', '.alert').html('设置已成功保存.');
+                        $('.alert').addClass('alert-success');
+                        $('.alert').removeClass('alert-warning');
+                    }
+
                     $('.alert').removeClass('alert-error');
                     $('.alert').removeClass('hide');
                 } else {
-                    $('.alert').html('发生未知错误.');
-                    $('.alert').addClass('alert-error');
-                    $('.alert').removeClass('alert-success');
-                    $('.alert').removeClass('hide');
+                    displayErrorMessage();
                 }
+            }, 
+            error: function() {
+                displayErrorMessage();
             }
         });
+    }
+</script>
+<script type="text/javascript">
+    function displayErrorMessage() {
+        $('.message', '.alert').html('发生未知错误, 请刷新页面重试.');
+        $('.alert').addClass('alert-error');
+        $('.alert').removeClass('alert-success');
+        $('.alert').removeClass('alert-warning');
+        $('.alert').removeClass('hide');
+    }
+</script>
+<script type="text/javascript">
+    function restatingService(serviceNameSlug) {
+        var serviceName     = '',
+            restatingTime   = 5,
+            messageTemplate = '正在重启服务[%s], 页面将在%s秒内刷新.';
+
+        if ( serviceNameSlug == 'goagent_enable' ) {
+            serviceName     = 'GoAgent';
+        } else if ( serviceNameSlug == 'php_enable' ) {
+            serviceName     = 'PHP代理';
+        } else {
+            serviceName     = 'Unknown';
+        }
+        $('.message', '.alert').html(messageTemplate.format(serviceName, restatingTime));
+
+        setTimeout(function () {
+            location.reload();
+        }, restatingTime * 1000);
     }
 </script>

--- a/php_proxy/1.0.0/local/web_control.py
+++ b/php_proxy/1.0.0/local/web_control.py
@@ -230,7 +230,6 @@ class RemoteContralServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             if reqs['cmd'] == ['get_config']:
                 data = json.dumps(user_config, default=lambda o: o.__dict__)
             elif reqs['cmd'] == ['set_config']:
-                user_config.php_enable = self.postvars['php_enable'][0]
                 user_config.php_password = self.postvars['php_password'][0]
                 user_config.php_server = self.postvars['php_server'][0]
                 user_config.proxy_enable = self.postvars['proxy_enable'][0]

--- a/php_proxy/1.0.0/web_ui/config.html
+++ b/php_proxy/1.0.0/web_ui/config.html
@@ -6,17 +6,6 @@
 <form id="goagent-php-config" method="POST" onSubmit="onSubmit(); return false;">
     <div class="row-fluid">
         <div class="span4">
-            <label for="enable-php-proxy">
-                启用PHP代理
-                <a href="https://github.com/XX-net/XX-Net/wiki/PHP-proxy" target="_blank">(帮助)</a>
-            </label>
-        </div> <!-- .span4 -->
-        <div class="span8">
-            <input id="enable-php-proxy" type="checkbox" data-toggle="switch" />
-        </div> <!-- .span8 -->
-    </div> <!-- .row-fluid -->
-    <div class="row-fluid">
-        <div class="span4">
             <label for="php-server">PHP Server URL</label>
         </div> <!-- .span4 -->
         <div class="span8">
@@ -75,7 +64,7 @@
     </div> <!-- #front-proxy-options -->
     <div class="row-fluid">
         <div class="span12">
-            <button class="btn btn-primary btn-block" type="submit">保存并重启GoAgent</button>
+            <button class="btn btn-primary btn-block" type="submit">保存并重启PHP代理</button>
         </div> <!-- .span12 -->
     </div> <!-- .row-fluid -->
 </form> <!-- #goagent-php-config -->
@@ -104,12 +93,6 @@
             url: 'http://127.0.0.1:8083/config?cmd=get_config',
             dataType: 'JSON',
             success: function(result) {
-                if ( typeof(result['php_enable']) != 'undefined' && result['php_enable'] != 0 ) {
-                    $('#enable-php-proxy').parent().removeClass('switch-off');
-                    $('#enable-php-proxy').parent().addClass('switch-on');
-
-                    $('#enable-php-proxy').prop('checked', true);
-                }
                 $('#php-server').val(result['php_server']);
                 $('#php-password').val(result['php_password']);
 
@@ -124,14 +107,20 @@
                 $('#proxy-port').val(result['proxy_port']);
                 $('#proxy-username').val(result['proxy_username']);
                 $('#proxy-password').val(result['proxy_password']);
+            },
+            error: function() {
+                $('.alert').html('PHP代理被禁用, 请先在<a href="/?module=launcher&menu=config">系统配置</a>的高级选项中启用PHP代理.');
+                $('.alert').addClass('alert-warning');
+                $('.alert').removeClass('alert-error');
+                $('.alert').removeClass('alert-success');
+                $('.alert').removeClass('hide');
             }
         });
     });
 </script>
 <script type="text/javascript">
     function onSubmit() {
-        var enablePhpProxy   = $('#enable-php-proxy').is(':checked') ? 1 : 0,
-            phpServer        = $('#php-server').val(),
+        var phpServer        = $('#php-server').val(),
             phpPassword      = $('#php-password').val(),
             enableFrontProxy = $('#enable-front-proxy').is(':checked') ? 1 : 0,
             proxyHost        = $('#proxy-host').val(),
@@ -139,15 +128,14 @@
             proxyUsername    = $('#proxy-username').val(),
             proxyPassword    = $('#proxy-password').val();
         
-        return setConfig(enablePhpProxy, phpServer, phpPassword, enableFrontProxy, 
+        return setConfig(phpServer, phpPassword, enableFrontProxy, 
                             proxyHost, proxyPort, proxyUsername, proxyPassword);
     }
 </script>
 <script type="text/javascript">
-    function setConfig(enablePhpProxy, phpServer, phpPassword, enableFrontProxy, 
+    function setConfig(phpServer, phpPassword, enableFrontProxy, 
                         proxyHost, proxyPort, proxyUsername, proxyPassword) {
         var config = {
-            'php_enable': enablePhpProxy, 
             'php_server': phpServer, 
             'php_password': phpPassword, 
             'proxy_enable': enableFrontProxy, 
@@ -167,13 +155,22 @@
                     $('.alert').html('设置已成功保存.');
                     $('.alert').addClass('alert-success');
                     $('.alert').removeClass('alert-error');
+                    $('.alert').removeClass('alert-warning');
                     $('.alert').removeClass('hide');
                 } else {
                     $('.alert').html('发生未知错误.');
                     $('.alert').addClass('alert-error');
                     $('.alert').removeClass('alert-success');
+                    $('.alert').removeClass('alert-warning');
                     $('.alert').removeClass('hide');
                 }
+            },
+            error: function() {
+                $('.alert').html('PHP代理被禁用, 请先在<a href="/?module=launcher&menu=config">系统配置</a>的高级选项中启用PHP代理.');
+                $('.alert').addClass('alert-warning');
+                $('.alert').removeClass('alert-error');
+                $('.alert').removeClass('alert-success');
+                $('.alert').removeClass('hide');
             }
         });
     }


### PR DESCRIPTION
## Changelog

1. 当GoAgent或PHP代理状态改变时自动刷新系统设置页面, 目前的策略是当开关触发后, 5秒后刷新页面. 因为我不知道后台的重启什么时候可以完成.(貌似`get_config`)状态不会有变化.
2. Refine HTML in some pages(主要是`GoAgent`的`status`和`config`). Status页面当获取状态失败时, 会自动滚动屏幕到顶部.
3. 去除了PHP代理配置页面中的开关, 同时删除了`web_control.py`的`user_config.php_enable = self.postvars['php_enable'][0]`. 应该没做错吧? 测试了好像没问题.