### PR TITLE
Purge site.js cache, fix #385

### DIFF
--- a/launcher/1.4.0/web_ui/index.html
+++ b/launcher/1.4.0/web_ui/index.html
@@ -18,7 +18,7 @@
     <script type="text/javascript" src="/js/jquery.timer.js"></script>
     <script type="text/javascript" src="/js/spin.min.js"></script>
     <script type="text/javascript" src="/js/ladda.min.js"></script>
-    <script type="text/javascript" src="/js/site.js"></script>
+    <script type="text/javascript" src="/js/site.js?20150512"></script>
     <!--[if lte IE 9]>
         <script type="text/javascript" src="/js/jquery.placeholder.min.js"></script>
         <script type="text/javascript" src="/js/jquery.xdomainrequest.min.js"></script>


### PR DESCRIPTION
标识符方面，用时间戳或者问题号都有麻烦（需要转换，不直观；无法预测），js也还没有版本号机制，所以干脆用日期吧。