### PR TITLE
(have bug,need help)To support gvs ip,add ECDHE... ciphers to ssl_sock generated by ssl module or OpenSSL module

### DIFF
--- a/goagent/3.1.49/local/openssl_wrap.py
+++ b/goagent/3.1.49/local/openssl_wrap.py
@@ -127,7 +127,7 @@ class SSLConnection(object):
 
             if sys.platform == "darwin":
                 ssl_version = "TLSv1"
-                
+
             logging.info("SSL use version:%s", ssl_version)
 
         protocol_version = getattr(OpenSSL.SSL, '%s_METHOD' % ssl_version)
@@ -137,6 +137,7 @@ class SSLConnection(object):
             ssl_context.set_verify(OpenSSL.SSL.VERIFY_PEER, lambda c, x, e, d, ok: ok)
         else:
             ssl_context.set_verify(OpenSSL.SSL.VERIFY_NONE, lambda c, x, e, d, ok: ok)
-        ssl_context.set_cipher_list(':'.join(cipher_suites))
+        #ssl_context.set_cipher_list(':'.join(cipher_suites))
+        ssl_context.set_cipher_list('ECDHE-RSA-AES128-SHA')
         return ssl_context
 

--- a/goagent/3.1.49/local/proxy_handler.py
+++ b/goagent/3.1.49/local/proxy_handler.py
@@ -181,7 +181,7 @@ class GAEProxyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         self.wfile.write(b'HTTP/1.1 200 OK\r\n\r\n')
 
         try:
-            ssl_sock = ssl.wrap_socket(self.connection, keyfile=certfile, certfile=certfile, server_side=True)
+            ssl_sock = ssl.wrap_socket(self.connection, keyfile=certfile, ciphers='ECDHE-RSA-AES128-SHA',certfile=certfile, server_side=True)
         except ssl.SSLError as e:
             logging.info('ssl error: %s, create full domain cert for host:%s', e, host)
             certfile = CertUtil.get_cert(host, full_name=True)
@@ -272,7 +272,7 @@ class GAEProxyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         self.wfile.write(b'HTTP/1.1 200 OK\r\n\r\n')
 
         try:
-            ssl_sock = ssl.wrap_socket(self.connection, keyfile=certfile, certfile=certfile, server_side=True)
+            ssl_sock = ssl.wrap_socket(self.connection, keyfile=certfile, ciphers='ECDHE-RSA-AES128-SHA',certfile=certfile, server_side=True)
         except ssl.SSLError as e:
             logging.info('ssl error: %s, create full domain cert for host:%s', e, host)
             certfile = CertUtil.get_cert(host, full_name=True)


### PR DESCRIPTION
因为ssl_sock是由ssl模块或者OpenSSL模块建立的，所以搜索了一下，在适当的位置添加指定的ciphers。
ssl模块创建ssl_sock是由ssl.wrap_socket实现的，直接添加在此函数的参数中，
而OpenSSL模块创建ssl_sock，则灵活（复杂）一点，先创建SSLContext，再用OpenSSL.SSL.Connection函数把SSLContext和socket合并起来。需要在SSLContext的创建过程中，用Context.set_cipher_list（ssl_context.set_cipher_list）函数指定ciphers。
测试结果：
1、可以正确添加gvs ip到good_ip.txt中，在good_ip.txt中显示为gws
2、用python2 start.py命令刚打开时，可以正常工作。但过一会就不断打印“warning no gws ip”警告，并且不能继续访问。好像是这些ip只能完成一次连接就被程序弃用了。具体原因未知。

调试时，把good_ip.txt,bad_ip2.txt删掉，ip_range.txt换成自己找到的gvs ips

# 需要帮助呀！！！