### PR TITLE
Avoid duplication fetch for logging page

### DIFF
--- a/goagent/3.1.49/web_ui/logging.html
+++ b/goagent/3.1.49/web_ui/logging.html
@@ -36,6 +36,7 @@
         window.previousOffset  = 0;
         window.offset          = 1;
         window.isAutoScrollLog = true;
+        window.isgetLogProcessing = false;
 
         var timer = $.timer(function() {
             getLog();
@@ -73,6 +74,8 @@
 </script>
 <script type="text/javascript">
     function getLog() {
+        if ( window.isgetLogProcessing ) { return }
+        window.isgetLogProcessing = true;
         var pageRequests = {
             'cmd': 'get_new',
             'last_no': offset
@@ -94,6 +97,10 @@
                     }
                 });
                 window.previousOffset = window.offset;
+                window.isgetLogProcessing = false;
+            },
+            error: function(xml, info, obj) {
+                window.isgetLogProcessing = false;
             }
         });
     }


### PR DESCRIPTION
模拟一个互斥/线程锁。

因为是500毫秒获取一次，如果当时负载较重（比如浏览器卡住），处理过程超过500毫秒，就会发起两次。那样会导致offset的值冲突，因而判断失误导致日志出现重复。