### PR TITLE
Implement Scan Blocked detect

### DIFF
--- a/goagent/3.1.49/local/check_ip.py
+++ b/goagent/3.1.49/local/check_ip.py
@@ -31,6 +31,7 @@ from config import config
 import cert_util
 from openssl_wrap import SSLConnection
 
+from connect_control import scan_sleep
 from google_ip_range import ip_range
 import ip_utils
 from appids_manager import appid_manager
@@ -226,8 +227,12 @@ def test_server_type(ssl_sock, ip):
         time_stop = time.time()
         time_cost = (time_stop - time_start)*1000
 
-        server_type = server_type.replace(" ", "_")
-        if server_type == '':
+        server_type = server_type.replace(" ", "_") # gvs 1.0
+        if server_type == 'HTTP_server_(unknown)':
+            res_url = response.msg.dict["location"]
+            if "google.com/sorry/IndexRedirect?" in res_url:
+                scan_sleep()
+        if server_type == '': # for avoid csv split
             server_type = '_'
         logging.info("server_type:%s time:%d", server_type, time_cost)
         return server_type

--- a/goagent/3.1.49/local/connect_control.py
+++ b/goagent/3.1.49/local/connect_control.py
@@ -5,8 +5,10 @@ import logging
 
 connect_allow_time = 0
 connect_fail_time = 0
+scan_allow_time = 0
 
 block_delay = 10 # (60 * 5)
+scan_sleep_time = 600 # Need examination
 
 
 def allow_connect():
@@ -16,10 +18,25 @@ def allow_connect():
     else:
         return True
 
+def allow_scan():
+    global scan_allow_time
+    if not allow_connect:
+        return False
+    if time.time() < scan_allow_time:
+        return False
+    else:
+        return True
+
 def fall_into_honeypot():
     logging.warn("fall_into_honeypot.")
     global connect_allow_time
     #connect_allow_time = time.time() + block_delay
+
+def scan_sleep():
+    logging.warn("Scan Blocked, due to exceeds Google's frequency limit. Please reduce the number of scan threads.")
+    global scan_allow_time
+    scan_allow_time = time.time() + scan_sleep_time
+    # DOTO: Auto-reduce the setting?
 
 def report_connect_fail():
     global connect_allow_time, connect_fail_time
@@ -35,9 +52,13 @@ def report_connect_success():
     connect_fail_time = 0
 
 def block_stat():
-    global connect_allow_time
+    global connect_allow_time, scan_allow_time
     wait_time = connect_allow_time - time.time()
-    if wait_time < 0:
+    scan_time = scan_allow_time - time.time()
+    if wait_time < 0 and scan_time < 0:
         return "OK"
-    else:
-        return "Blocked, %d seconds to wait." % wait_time
+    elif wait_time > 0:
+        return "Connect Blocked, %d seconds to wait." % wait_time
+    elif scan_time > 0:
+        return "Scan Blocked, %d seconds to wait." % scan_time
+

--- a/goagent/3.1.49/local/google_ip.py
+++ b/goagent/3.1.49/local/google_ip.py
@@ -458,7 +458,7 @@ class Check_ip():
 
     def scan_ip_worker(self):
         while self.searching_thread_count <= self.max_check_ip_thread_num:
-            if not connect_control.allow_connect():
+            if not connect_control.allow_scan():
                 time.sleep(10)
                 continue
 


### PR DESCRIPTION
检测功能，避免在遇到“异常流量”警告后继续扫描。
将扫描线程数调到比如500，持续运行数分钟，就能看到这样的警告。

警告页面参考 https://ipv4.google.com/sorry/IndexRedirect

备注：如果检测机制改成只获取和检查证书但不获取资源，频率高也不会触发这样的警告。