### PR TITLE
Refine logs function

### DIFF
--- a/goagent/3.1.49/local/google_ip.py
+++ b/goagent/3.1.49/local/google_ip.py
@@ -183,7 +183,8 @@ class Check_ip():
             self.ip_lock.release()
 
         time_cost = (( time.time() - self.last_sort_time_for_gws) * 1000)
-        logging.debug("sort ip time:%d", time_cost) # 5ms for 1000 ip.
+        if time_cost < 30: return
+        logging.debug("sort ip time:%dms", time_cost) # 5ms for 1000 ip. 70~150ms for 30000 ip.
 
     def get_gws_ip(self):
         self.try_sort_ip_by_handshake_time()

--- a/goagent/3.1.49/local/logging.py
+++ b/goagent/3.1.49/local/logging.py
@@ -127,7 +127,7 @@ def set_buffer_size(set_size):
     buffer_len = len(buffer)
     buffer_lock.release()
 
-def get_last_lines(max_lines):
+def get_last_lines(max_lines): # Unused?
     global buffer_size, buffer, buffer_lock
 
     buffer_lock.acquire()

--- a/goagent/3.1.49/local/logging.py
+++ b/goagent/3.1.49/local/logging.py
@@ -137,7 +137,7 @@ def get_last_lines(max_lines): # Unused?
         for i in range(last_no - buffer_len + 1, last_no+1):
             jd[i] = buffer[i]
     buffer_lock.release()
-    return json.dumps(jd)
+    return json.dumps(jd, sort_keys=True)
 
 def get_new_lines(from_no):
     global buffer_size, buffer, buffer_lock
@@ -151,4 +151,4 @@ def get_new_lines(from_no):
         for i in range(from_no, last_no+1):
             jd[i] = buffer[i]
     buffer_lock.release()
-    return json.dumps(jd)
+    return json.dumps(jd, sort_keys=True)

--- a/goagent/3.1.49/local/logging.py
+++ b/goagent/3.1.49/local/logging.py
@@ -147,7 +147,7 @@ def get_new_lines(from_no):
     first_no = last_no - len(buffer) + 1
     if from_no < first_no:
         from_no = first_no
-    if last_no >= from_no:
+    if last_no > from_no:
         for i in range(from_no, last_no+1):
             jd[i] = buffer[i]
     buffer_lock.release()

--- a/goagent/3.1.49/local/web_control.py
+++ b/goagent/3.1.49/local/web_control.py
@@ -257,7 +257,7 @@ class RemoteContralServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         elif path == "/status":
             return self.req_status_handler()
         else:
-            logging.debug('GoAgent Web_control %s "%s %s ', self.address_string(), self.command, self.path)
+            logging.debug('GoAgent Web_control %s %s %s ', self.address_string(), self.command, self.path)
 
 
         if path == '/deploy':
@@ -394,7 +394,7 @@ class RemoteContralServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             last_no = int(reqs["last_no"][0])
             data = logging.get_new_lines(last_no)
         else:
-            logging.error('PAC %s "%s %s ', self.address_string(), self.command, self.path)
+            logging.error('PAC %s %s %s ', self.address_string(), self.command, self.path)
 
         mimetype = 'text/plain'
         self.send_response(mimetype, data)

--- a/goagent/3.1.49/web_ui/logging.html
+++ b/goagent/3.1.49/web_ui/logging.html
@@ -87,15 +87,19 @@
             data: pageRequests,
             dataType: 'JSON',
             success: function(result) {
+                var newlines = document.createDocumentFragment();
                 $.each(result, function(lineNumber, log) {
                     window.offset = lineNumber;
 
                     var logTemplate = '<p class="%s">%s</p>';
                     if ( window.previousOffset != window.offset ) {
-                        $('#log').append(logTemplate.format(getLogLevel(log), log));
-                        scrollLog();
+                        var newline = $(logTemplate.format(getLogLevel(log), log));
+                        $(newlines).append(newline);
                     }
                 });
+                // $('#log > p').slice(0,-1000).remove();
+                $('#log').append(newlines);
+                scrollLog();
                 window.previousOffset = window.offset;
                 window.isgetLogProcessing = false;
             },

--- a/goagent/3.1.49/web_ui/scan_ip.html
+++ b/goagent/3.1.49/web_ui/scan_ip.html
@@ -53,18 +53,13 @@
             dataType: 'html',
             success: function(result) {
                 $('#log').html(result.replace(/\n/g, '<br>'));
+                $('#log').scrollTop($('#log')[0].scrollHeight);
             },
             error: function(){
                 tip('读取日志失败.', 'error');
             }
         });
     }
-    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-        var target = e.target.attributes.href.value;
-        if(target == "#logs"){
-            $('#log').scrollTop($('#log')[0].scrollHeight);
-        }
-    })
 </script>
 <script type="text/javascript">
     $(function() {

--- a/launcher/1.4.0/web_control.py
+++ b/launcher/1.4.0/web_control.py
@@ -103,7 +103,7 @@ class Http_Handler(BaseHTTPServer.BaseHTTPRequestHandler):
         except:
             pass
         
-        logging.debug ('launcher web_control %s "%s %s ', self.address_string(), self.command, self.path)
+        logging.debug ('launcher web_control %s %s %s ', self.address_string(), self.command, self.path)
         # check for '..', which will leak file
         if re.search(r'(\.{2})', self.path) is not None:
             self.wfile.write(b'HTTP/1.1 404\r\n\r\n')

--- a/php_proxy/1.0.0/local/web_control.py
+++ b/php_proxy/1.0.0/local/web_control.py
@@ -147,7 +147,7 @@ class RemoteContralServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             sys.exit()
             return
         else:
-            logging.debug('PHP Web_control %s "%s %s ', self.address_string(), self.command, self.path)
+            logging.debug('PHP Web_control %s %s %s ', self.address_string(), self.command, self.path)
             self.wfile.write(b'HTTP/1.1 404\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n404 Not Found')
             logging.info('%s "%s %s HTTP/1.1" 404 -', self.address_string(), self.command, self.path)
 
@@ -216,7 +216,7 @@ class RemoteContralServerHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             last_no = int(reqs["last_no"][0])
             data = logging.get_new_lines(last_no)
         else:
-            logging.error('PAC %s "%s %s ', self.address_string(), self.command, self.path)
+            logging.error('PAC %s %s %s ', self.address_string(), self.command, self.path)
 
         mimetype = 'text/plain'
         self.send_response(mimetype, data)


### PR DESCRIPTION
* 主要
    * 改善添加性能，一次获取只进行一次添加和一次滚动操作（DOM）。
    * 自动移除旧日志语句已注释，参数和方式未考虑好。持续添加会导致内存持续增长。但如果超出指定值后每次获取（500ms）都修剪似乎也增加了负担，虽然我这里看上去不卡。
    * 获取时，如果没有新日志，可直接返回0字节响应（200 OK），减少传输和判断消耗。
    * 尝试改善稳定性。有时会突然持续添加重复的日志，症状为返回的JSON中第一项不是最低项（最低项跑到了最后一项）导致检查失误。原因不明，遇到过多次，希望排序能够解决。
    * 很小的排序耗时不必输出，跳过小于30ms（大约6000 ip）的输出。
    * 扫描日志目前仅在载入或手动刷新时更新，所以每次更新时跳转到最底部就可以了。
* 次要
    * 配平引号。
    * get_last_lines 用途不明，如果已废弃，请考虑删除。