### PR TITLE
add a dummy good_ip file

### DIFF
--- a/gae_proxy/local/good_ip_default.txt
+++ b/gae_proxy/local/good_ip_default.txt
@@ -1,0 +1,5 @@
+210.61.221.168 google.com gws 180
+208.117.236.172 *.c.docs.google.com gws 521
+85.182.250.173 google.com gws 534
+64.15.116.148 google.com gws 541
+128.0.169.250 *.googlevideo.com gws 554

--- a/gae_proxy/local/google_ip.py
+++ b/gae_proxy/local/google_ip.py
@@ -41,7 +41,7 @@ class Check_ip():
     else:
         good_ip_file_name = "good_ip.txt"
         bad_ip_file_name = "bad_ip2.txt"
-        default_good_ip_file_name = "good_ip.txt"
+        default_good_ip_file_name = "good_ip_default.txt"
     good_ip_file = os.path.abspath( os.path.join(config.DATA_PATH, good_ip_file_name))
     bad_ip_file = os.path.abspath( os.path.join(config.DATA_PATH, bad_ip_file_name))
     default_good_ip_file = os.path.join(current_path, default_good_ip_file_name)


### PR DESCRIPTION
默认情况是读取的3000+ ip的文件，但GFW对不同地域的封锁策略不同，可能会导致用户启动xxnet后，在状态页中看到的Google IP num数量接近3000，但日志中却不断报链接failed。

现在更改为基本从0开始扫ip，以免用户“误解”，请xxnet老大看看是否合适，谢谢。