### PR TITLE
freenas openssl support fix

### DIFF
--- a/gae_proxy/local/openssl_wrap.py
+++ b/gae_proxy/local/openssl_wrap.py
@@ -128,6 +128,11 @@ class SSLConnection(object):
 
             if sys.platform == "darwin":
                 ssl_version = "TLSv1"
+            
+            # freenas openssl support fix from twitter user "himanzero"
+            # https://twitter.com/himanzero/status/645231724318748672
+            if sys.platform == "freebsd9":
+                ssl_version = "TLSv1"
 
             xlog.info("SSL use version:%s", ssl_version)
 


### PR DESCRIPTION
from twitter user "himanzero"
https://twitter.com/himanzero/status/645231724318748672
```
Himan Zero ‏@himanzero Sep 19

在FreeNAS里装上XX-Net，出错，调试发现FreeBSD的OpenSSL不支持TLSv1_2。于是在openssl_wrap.py相应位置加了一行if sys.platform == "freebsd9": ssl_version = "TLSv1"，搞定。#人生经验+1
```
闲逛twitter时发现 :laughing: 


