### PR TITLE
运行该脚本需要 root 权限

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ $EUID -ne 0 ]]; then
+    echo "Please run as root"
+    exit 1
+fi
+
 SCRIPTPATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPTPATH
 


### PR DESCRIPTION
在Linux环境下运行`start.sh` 需要root权限；
因此在`start.sh`中检查是否以root权限运行