### PR TITLE
Correct an English grammatic error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-XX-Net - A Reborn of Goagent
+XX-Net - A Reborn Goagent
 ========
 翻墙工具套件 A firewall circumvention toolkit
 * GAE proxy, 稳定、易用、快速  


### PR DESCRIPTION
A small improvement: "A Reborn of Goagent" should be "A Reborn Goagent".