### PR TITLE
[OS X] Specify bash in start.command

### DIFF
--- a/start.command
+++ b/start.command
@@ -1,2 +1,3 @@
+#!/bin/bash
 cd "$(dirname "$0")"
 /usr/bin/env python2.7 launcher/start.py


### PR DESCRIPTION
我用fish作为默认shell，它与bash语法不兼容，执行start.command时会出错。
在头部声明bash可解决此问题。