### PR TITLE
Mobile browser can browse webcontrol and download ca.cert correctly

### DIFF
--- a/gae_proxy/local/proxy_handler.py
+++ b/gae_proxy/local/proxy_handler.py
@@ -100,6 +100,10 @@ class GAEProxyHandler(simple_http_server.HttpServerHandler):
             #xlog.warn("Your browser forward localhost to proxy.")
             return self.forward_local()
 
+        if host_ip in socket.gethostbyname_ex(socket.gethostname())[-1]:
+            xlog.info("Browse localhost by proxy")
+            return self.forward_local()
+
         if self.path == "http://www.twitter.com/xxnet":
             xlog.debug("%s %s", self.command, self.path)
             # for web_ui status page

--- a/gae_proxy/web_ui/status.html
+++ b/gae_proxy/web_ui/status.html
@@ -282,10 +282,8 @@
             success: function(result) {
                 if ( test_http_proxy_setting() == "OK"){
                     var ca_status_str = test_https_proxy_setting();
-                    $("#tr_ca-status").show();
                 }else{
-                    var ca_status_str = "";
-                    $("#tr_ca-status").hide();
+                    var ca_status_str = "Fail";
                 }
 
                 var updates = {


### PR DESCRIPTION
1. mobile browser can browse server correctly
2. 'enable_remote_web_control ' must be set 'on' in config page