### PR TITLE
Update web_control.py

### DIFF
--- a/launcher/web_control.py
+++ b/launcher/web_control.py
@@ -470,8 +470,10 @@ def confirm_xxnet_exit():
 
     for i in range(30):
         # gae_proxy(default port:8087)
-        if http_request("http://127.0.0.1:8087/quit") == False:
-            xlog.debug("good, xxnet:8087 cleared!")
+        xxnet_port = config.get(["modules", "launcher", "xxnet_port"], 8087)
+        req_url = "http://127.0.0.1:{port}/quit".format(port=xxnet_port)
+        if http_request(req_url) == False:
+            xlog.debug("good, xxnet:%s clear!" % xxnet_port)
             is_xxnet_exit = True
             break
         else:


### PR DESCRIPTION
Instead of killing hard-coded port 8087, gives the option to kill a xxnet port as specified in data/launcher/config.yaml