### PR TITLE
Update config.py

### DIFF
--- a/launcher/config.py
+++ b/launcher/config.py
@@ -60,6 +60,8 @@ def recheck_module_path():
     global config
     need_save_config = False
 
+    xxnet_port = get(["modules", "gae_proxy", "LISTEN_PORT"], 8087)
+
     modules = ["gae_proxy", "launcher", "php_proxy", "x_tunnel"]
     for module in modules:
         if module not in ["launcher", "php_proxy"]:
@@ -69,6 +71,9 @@ def recheck_module_path():
 
             if get(["modules", module, "auto_start"], -1) == -1:
                 set(["modules", module, "auto_start"], 1)
+
+    if get(["modules", "launcher", "xxnet_port"], 0) == 0:
+        set(["modules", "launcher", "xxnet_port"], xxnet_port)
 
     if get(["modules", "launcher", "control_port"], 0) == 0:
         set(["modules", "launcher", "control_port"], 8085)


### PR DESCRIPTION
A refinement of my previous patch. Now listening port is read from gae_proxy.LISTEN_PORT. That means listening port can be specified by user in .ini file as usual. It is not necessary to specify the listening port separately in data/launcher/config.yaml