### PR TITLE
Improve messages

### DIFF
--- a/gae_proxy/lang/de_DE/LC_MESSAGES/messages.po
+++ b/gae_proxy/lang/de_DE/LC_MESSAGES/messages.po
@@ -48,7 +48,7 @@ msgid "Needless to configure generally"
 msgstr ""
 
 #: web_ui/config.html:37
-msgid "Enable IPv6(CERNet only)"
+msgid "Enable IPv6(If it's available)"
 msgstr ""
 
 #: web_ui/config.html:45

--- a/gae_proxy/lang/es_VE/LC_MESSAGES/messages.po
+++ b/gae_proxy/lang/es_VE/LC_MESSAGES/messages.po
@@ -48,7 +48,7 @@ msgid "Needless to configure generally"
 msgstr ""
 
 #: web_ui/config.html:37
-msgid "Enable IPv6(CERNet only)"
+msgid "Enable IPv6(If it's available)"
 msgstr ""
 
 #: web_ui/config.html:45

--- a/gae_proxy/lang/fa_IR/LC_MESSAGES/messages.po
+++ b/gae_proxy/lang/fa_IR/LC_MESSAGES/messages.po
@@ -354,14 +354,14 @@ msgstr "بحث"
 msgid "Show Details"
 msgstr "نمایش جزئیات"
 
-msgid "The Post to Github Issue needs to sign in your Github account"
+msgid "Post to Github issue needs to sign in your Github account"
 msgstr "بازخورد یک کلید نیاز به ثبت نام در حساب github خود را"
 
 msgid "To Google Groups"
 msgstr "به Google Groups"
 
-msgid "Post to Github Issue"
-msgstr "بررسی مسائل _Github_"
+msgid "Post to Github Issue..."
+msgstr "بررسی مسائل _Github_..."
 
 msgid "GAE Proxy Status Info"
 msgstr "GAE پروکسی وضعیت"

--- a/gae_proxy/lang/fa_IR/LC_MESSAGES/messages.po
+++ b/gae_proxy/lang/fa_IR/LC_MESSAGES/messages.po
@@ -82,7 +82,7 @@ msgstr "توجه: غیر قابل دسترس قبل از appids مستقر هس�
 msgid "Advanced options"
 msgstr "گزینه های پیشرفته"
 
-msgid "Enable IPv6(CERNet only)"
+msgid "Enable IPv6(If it's available)"
 msgstr "فعال کردن IPv6 را (سرنت تنها)"
 
 msgid "LAN proxy(Generally not needed)"

--- a/gae_proxy/lang/ja_JP/LC_MESSAGES/messages.po
+++ b/gae_proxy/lang/ja_JP/LC_MESSAGES/messages.po
@@ -48,7 +48,7 @@ msgid "Needless to configure generally"
 msgstr ""
 
 #: web_ui/config.html:37
-msgid "Enable IPv6(CERNet only)"
+msgid "Enable IPv6(If it's available)"
 msgstr ""
 
 #: web_ui/config.html:45

--- a/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
@@ -80,7 +80,7 @@ msgstr "注意：appid部署之前无法使用。"
 msgid "Advanced options"
 msgstr "高级选项"
 
-msgid "Enable IPv6(CERNet only)"
+msgid "Enable IPv6(If it's available)"
 msgstr "使用IPv6(一般教育网才开)"
 
 msgid "LAN proxy(Generally not needed)"

--- a/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
@@ -448,3 +448,9 @@ msgstr "全局代理已禁用"
 
 msgid "Download"
 msgstr "下载"
+
+msgid "new:"
+msgstr "新:"
+
+msgid " used:"
+msgstr " 已用:"

--- a/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
@@ -335,25 +335,25 @@ msgid "Diagnostic Info"
 msgstr "诊断信息"
 
 msgid "Check Github issues"
-msgstr "查看Github的问题讨论"
+msgstr "查看Github上的问题讨论区"
 
 msgid " or "
-msgstr "或者"
+msgstr " 或者"
 
 msgid " Discussions"
-msgstr "讨论"
+msgstr "讨论组"
 
 msgid "Show Details"
 msgstr "显示详细信息"
 
-msgid "The Post to Github Issue needs to sign in your Github account"
-msgstr "发到github问题区需要登录Github账号"
+msgid "Post to Github issue needs to sign in your Github account"
+msgstr "贴到Github问题区需要登录Github账号"
 
 msgid "To Google Groups"
 msgstr "前往Google论坛"
 
-msgid "Post to Github Issue"
-msgstr "发到github问题区"
+msgid "Post to Github Issue..."
+msgstr "贴到Github问题区..."
 
 msgid "GAE Proxy Status Info"
 msgstr "GAEProxy状态信息"
@@ -454,3 +454,7 @@ msgstr "新:"
 
 msgid " used:"
 msgstr " 已用:"
+
+msgid "-----------%0AProblem Description:%0APlease describe your problem, running logs may be needed.%0A%0A-----------%0ADiagnostic information:%0A"
+msgstr "-----------%0A问题描述：%0A请在此描述你遇到的问题，必要时贴出相关的日志信息。%0A%0A-----------%0A诊断信息：%0A"
+

--- a/gae_proxy/local/web_control.py
+++ b/gae_proxy/local/web_control.py
@@ -480,7 +480,7 @@ class ControlHandler(simple_http_server.HttpServerHandler):
                 if user_config.user_special.use_ipv6 != use_ipv6:
                     if use_ipv6:
                         if not check_local_network.check_ipv6():
-                            xlog.warn("Enable Ipv6 but check failed.")
+                            xlog.warn("IPv6 was enabled, but check failed.")
                             return self.send_response('text/html', '{"res":"fail", "reason":"IPv6 fail"}')
 
                     user_config.user_special.use_ipv6 = use_ipv6

--- a/gae_proxy/web_ui/config.html
+++ b/gae_proxy/web_ui/config.html
@@ -26,7 +26,7 @@
     <div id="advanced-options" style="display: none;">
         <div class="row-fluid">
             <div class="span4">
-                <label for="use-ipv6">{{ _( "Enable IPv6(CERNet only)" ) }}</label>
+                <label for="use-ipv6">{{ _( "Enable IPv6(If it's available)" ) }}</label>
             </div> <!-- .span4 -->
             <div class="span8">
                 <input id="use-ipv6" type="checkbox" data-toggle="switch" />

--- a/gae_proxy/web_ui/status.html
+++ b/gae_proxy/web_ui/status.html
@@ -182,12 +182,12 @@
         <h3>{{ _( "Diagnostic Info" ) }}</h3>
     </div> <!-- .modal-header -->
     <div class="modal-body">
-        <p> * {{ _( "The Post to Github Issue needs to sign in your Github account" ) }}</p>
+        <p> * {{ _( "Post to Github issue needs to sign in your Github account" ) }}</p>
         <textarea id="DiagInfo" onmouseover="this.focus();this.select()"></textarea>
     </div>
     <div class="modal-footer">
         <a href="https://groups.google.com/forum/#!forum/xx-net"  id="go-to-google-group" class="btn btn-primary " target="_blank">{{ _( "To Google Groups" ) }}</a>
-        <a href="https://github.com/XX-net/XX-Net/issues"  id="one-key-issue" class="btn btn-success " target="_blank">{{ _( "Post to Github Issue" ) }}</a>
+        <a href="https://github.com/XX-net/XX-Net/issues"  id="one-key-issue" class="btn btn-success " target="_blank">{{ _( "Post to Github Issue..." ) }}</a>
     </div> <!-- .modal-footer -->
 </div> <!-- #report-issue-modal -->
 
@@ -229,9 +229,9 @@
                     'Using_Public_Appid: ' + is_public_appid(result['gae_appid'])
                     );
 
-                updateProperty("textarea#DiagInfo","XX-Net Status：\n\n" + information.join("\n"));
+                updateProperty("textarea#DiagInfo","XX-Net Status:\n\n" + information.join("\n"));
 
-                IssueURL = 'https://github.com/XX-net/XX-Net/issues/new?body=-----------%0A问题描述：%0A请在此描述你遇到的问题，必要时贴出相关的日志信息。%0A%0A-----------%0A诊断信息：%0A' + encodeURIComponent(information.join("\n")) + ";";
+                IssueURL = 'https://github.com/XX-net/XX-Net/issues/new?body={{ _( "-----------%0AProblem Description:%0APlease describe your problem, running logs may be needed.%0A%0A-----------%0ADiagnostic information:%0A" ) }}' + encodeURIComponent(information.join("\n")) + ";"; 
                 $("a#one-key-issue").attr("href",IssueURL);
                 GGroupURL = "https://groups.google.com/forum/#!forum/xx-net";
                 // The one-key generaton function is to be designed as Github does有待设计类似Github Issue的一键生成功能

--- a/gae_proxy/web_ui/status.html
+++ b/gae_proxy/web_ui/status.html
@@ -214,9 +214,9 @@
                     'python-version: ' + result['python_version'],
 
                     '\nipv6-status: ' + result['use_ipv6'],
-                    'gws-ip-num: ' + result['ip_num'] + ' / ' + result['good_ip_num'],
+                    'gws-ip-num: ' + 'total:' + result['ip_num'] + ' good:' + result['good_ip_num'],
                     'network-status: ' + result['network_state'],
-                    'connected-link: ' + result['connected_link_new'] + " / " + result['connected_link_used'],
+                    'connected-link: ' + 'new:' + result['connected_link_new'] + ' used:'+ result['connected_link_used'],
                     'scan-ip-thread-num: ' + result['scan_ip_thread_num'],
                     'ip-quality: ' + result['ip_quality'],
                     'block-stat: ' + result['block_stat'],
@@ -431,8 +431,7 @@
         }
     }
     function connection_status_string(connected_link_new, connected_link_used){
-        var conn_str = connected_link_new + " / " + connected_link_used;
-        return conn_str;
+        return conn_str = '{{ _( "new:" ) }}' + connected_link_new + '{{ _( " used:" ) }}'+ connected_link_used;
     }
     function proxy_status_string(proxy_state,proxy_url){
         if (proxy_state == "Auto proxy enabled"){


### PR DESCRIPTION
思路：
* 语义化数字含义。OS Detail和UA也有冒号，所以重叠的结构应该没问题。
* 对于外国用户，CERNet这种描述不必要。为了避免误解为全自动检测（实际也是，但会有提示出现），没有用'(If available)'。不确定'Enabled IPv6'是否更适合。
* 加'...'避免误解为直接发送，虽然也能从链接看出来，但不保险也不贴合用户。其实正规写法是GitHub，但Github应该也行，全小写则比较不规范。i18n模板内容。

问题：
* po文件是如何更新的，目前有一个翻译平台或提取工具吗。用poedit提取（生成po）失败，默认它好像不支持html文件。
* 有一个'You may want to'字符串在po文件中不完整，需要纠正和翻译。