### PR TITLE
Fix get_version_fail in xxnet_version

### DIFF
--- a/gae_proxy/local/web_control.py
+++ b/gae_proxy/local/web_control.py
@@ -350,18 +350,11 @@ class ControlHandler(simple_http_server.HttpServerHandler):
 
     @staticmethod
     def xxnet_version():
-        readme_file = os.path.join(root_path, "README.md")
+        version_file = os.path.join(root_path, "version.txt")
         try:
-            fd = open(readme_file, "r")
-            lines = fd.readlines()
-            import re
-            p = re.compile(r'https://codeload.github.com/XX-net/XX-Net/zip/([0-9]+)\.([0-9]+)\.([0-9]+)') #zip/([0-9]+).([0-9]+).([0-9]+)
-            #m = p.match(content)
-            for line in lines:
-                m = p.match(line)
-                if m:
-                    version = m.group(1) + "." + m.group(2) + "." + m.group(3)
-                    return version
+            fd = open(version_file, "r")
+            version = fd.read()
+            return version
         except Exception as e:
             xlog.exception("xxnet_version fail")
         return "get_version_fail"


### PR DESCRIPTION
在 https://github.com/XX-net/XX-Net/commit/7e2ef7b70336962c5dfc38544c300180c29ffcc9 开始失效。

新的代码会允许代码嵌入网页，可能带来恶意代码问题。不过直接在子目录的文件插入代码是一样的，并且更隐蔽，所以好像不是问题。
未测试version.txt的自动更新效果。