### PR TITLE
Always refresh check_ip interface

### DIFF
--- a/gae_proxy/web_ui/check_ip.html
+++ b/gae_proxy/web_ui/check_ip.html
@@ -57,7 +57,6 @@
                 }
 
                 if ( result['left_num'] == 0 ){
-                    window.timer.stop();
                     enableStartButton();
                 }else{
                     disableStartButton();


### PR DESCRIPTION
非检查状态也应该刷新所有和可用IP，方便查看。这个界面比状态页面的信息更简洁。