### PR TITLE
Improve 160328,  add a remote-connection-identifier, etc.

### DIFF
--- a/gae_proxy/lang/fa_IR/LC_MESSAGES/messages.po
+++ b/gae_proxy/lang/fa_IR/LC_MESSAGES/messages.po
@@ -388,10 +388,6 @@ msgstr "به عیب یابی."
 msgid "Your local network failed. Please check your network and firewall. "
 msgstr "شبکه محلی شما را شکست خورده است. لطفا شبکه و فایروال خود را چک کنید."
 
-msgid ""
-"You may want to <a "
-msgstr ""
-
 msgid "XX-Net is scanning IP. Please wait about half an hour."
 msgstr "_XX-Net_ اسکن است. لطفا صبر کنید."
 

--- a/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
@@ -140,9 +140,6 @@ msgstr "保存设置失败"
 msgid "Deploy XX-Net onto GAE"
 msgstr "部署XX-Net至GAE"
 
-msgid "Current status"
-msgstr "当前状态"
-
 msgid "idle"
 msgstr "空闲"
 

--- a/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
@@ -375,9 +375,8 @@ msgstr "查找问题原因。"
 msgid "Your local network failed. Please check your network and firewall. "
 msgstr "网络无法连接，请检查网络和防火墙设置。"
 
-msgid ""
-"You may want to <a "
-msgstr ""
+msgid "You may want to $1turn on IP scaner$2."
+msgstr "您应该考虑$1开启 IP 扫描器$2。"
 
 msgid "XX-Net is scanning IP. Please wait about half an hour."
 msgstr "请等待大约半小时，XX-Net需要扫描IP。"

--- a/gae_proxy/web_ui/deploy.html
+++ b/gae_proxy/web_ui/deploy.html
@@ -1,6 +1,6 @@
 <h2>{{ _( "Deploy XX-Net onto GAE" ) }}</h2>
 <div class="alert alert-info fade in">
-    <p class="message">{{ _( "Current status" ) }}: {{ _( "idle" ) }}</p>
+    <p class="message">{{ _( "Current status: " ) }}{{ _( "idle" ) }}</p>
 </div> <!-- .alert -->
 <ul class="nav nav-tabs">
     <li class="active"><a href="#authentication" data-toggle="tab">{{ _( "Authorization" ) }}</a></li>

--- a/gae_proxy/web_ui/status.html
+++ b/gae_proxy/web_ui/status.html
@@ -46,7 +46,7 @@
                 <td id="scan-ip-thread-num"></td>
             </tr>
             <tr>
-                <td>{{ _( "Block Status" ) }} (<a href="https://github.com/XX-net/XX-Net/wiki/GoAgent-Blocked" target="_blank">{{ _( "Help" ) }}</a>)</td>
+                <td>{{ _( "Block Status" ) }}(<a href="https://github.com/XX-net/XX-Net/wiki/GoAgent-Blocked" target="_blank">{{ _( "Help" ) }}</a>)</td>
                 <td id="block-stat"></td>
             </tr>
             <!--tr pro="False">

--- a/gae_proxy/web_ui/status.html
+++ b/gae_proxy/web_ui/status.html
@@ -365,7 +365,7 @@
 
                 if ( result['good_ip_num'] < 1){
                     if ( result['scan_ip_thread_num'] < 3 ){
-                        return updateProperty('#noob-info', '{{ _( "You may want to <a href=\"./?module=gae_proxy&menu=advanced#scan_ip\">turn on IP scaner</a>." ) }}', 'none');
+                        return updateProperty('#noob-info', '{{ _( "You may want to $1turn on IP scaner$2." ) }}'.replace('$1', '<a href=\"./?module=gae_proxy&menu=advanced#scan_ip\">').replace('$2', '</a>'), 'none');
                     }else{
                         return updateProperty('#noob-info', '{{ _( "XX-Net is scanning IP. Please wait about half an hour." ) }}', 'none');
                     }

--- a/launcher/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/launcher/lang/zh_CN/LC_MESSAGES/messages.po
@@ -148,3 +148,8 @@ msgstr "关于"
 msgid "(Remote Web Control Enabled)"
 msgstr "(已允许远程连接)"
 
+msgid "Adaptive width"
+msgstr "自适应宽度"
+
+msgid "Exit the program"
+msgstr "退出程序"

--- a/launcher/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/launcher/lang/zh_CN/LC_MESSAGES/messages.po
@@ -145,3 +145,6 @@ msgstr "配置"
 msgid "About"
 msgstr "关于"
 
+msgid "(Remote Web Control Enabled)"
+msgstr "(已允许远程连接)"
+

--- a/launcher/web_control.py
+++ b/launcher/web_control.py
@@ -420,7 +420,7 @@ process = 0
 server = 0
 def start():
     global process, server
-    # should use config.yaml to bing ip
+    # should use config.yaml to bind ip
     allow_remote = config.get(["modules", "launcher", "allow_remote_connect"], 0)
     host_port = config.get(["modules", "launcher", "control_port"], 8085)
 

--- a/launcher/web_ui/css/style.css
+++ b/launcher/web_ui/css/style.css
@@ -48,10 +48,6 @@ select:focus {
     outline: none;
 }
 
-.color-red {
-    color: red;
-}
-
 div#header a {
     color: #fff;
     text-decoration: none;

--- a/launcher/web_ui/index.html
+++ b/launcher/web_ui/index.html
@@ -39,12 +39,12 @@
                     <div class="span4 text-right">
                         <ul class="inline">
                             <li>
-                                <a id="resize-window-trigger" href="javascript:void(0);" title="自适应宽度">
+                                <a id="resize-window-trigger" href="javascript:void(0);" title='{{ _( "Adaptive width" ) }}'>
                                     <img src="/img/fixed-width.png" alt="resize-window">
                                 </a>
                             </li>
                             <li>
-                                <a id="quit-trigger" href="javascript:void(0);" title="退出">
+                                <a id="quit-trigger" href="javascript:void(0);" title='{{ _( "Exit the program" ) }}'>
                                     <img src="/img/quit.png" alt="quit">
                                 </a>
                             </li>

--- a/launcher/web_ui/index.html
+++ b/launcher/web_ui/index.html
@@ -34,6 +34,7 @@
                             <img src="/img/logo.png" alt="Logo">
                             XX-Net
                         </a>
+                        <a id="remote-connection-identifier" style="display: none;" href="/?module=launcher&menu=config">{{ _( "(Remote Web Control Enabled)" ) }}</a>
                     </div> <!-- #logo -->
                     <div class="span4 text-right">
                         <ul class="inline">
@@ -111,6 +112,23 @@
                     tip('{{ _( "Exitting failed. A network error occurred." ) }}', 'error');
                 }
             });
+        });
+    </script>
+    <script type="text/javascript">
+        var pageRequests = {
+            'cmd': 'get_config'
+        };
+
+        $.ajax({
+            type: 'GET',
+            url: '/config',
+            data: pageRequests,
+            dataType: 'JSON',
+            success: function(result) {
+                if ( result['allow_remote_connect'] != 0 ) {
+                    $('#remote-connection-identifier').show();
+                }
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
* 添加一个标识符，避免不知不觉/忘记启用了远程连接造成安全风险。
  * 其实若支持HTTP基本验证、SSL通讯等更好，但均非主要功能，开发资源紧张先不管吧。
  * 有考虑用红字，但目前白字也很醒目。那个规则似乎无作用且没有被使用，清理。
  * 英文版中描述较长，但也足够放，缩写或者图标感觉会降低作用。
  * 已测试无字符串的语言会自动采用英语。
  * `{{ _( `中必须用双引号，不然程序执行时陷入死循环，控制台在不断输出网页代码。
* 临时解决`#`字符被脚本替换截断的问题，#2401 曾提到。
  * 未来可以弄一个翻译平台，比如用 http://docs.transifex.com/client/setup/
  * https://hosted.weblate.org 界面也不错，申请需人工审核 (https://weblate.org/zh-hans/hosting/) 不知道遇到了什么困难。