### PR TITLE
Revert "use bootstrapSwitch to switch"

### DIFF
--- a/gae_proxy/web_ui/config.html
+++ b/gae_proxy/web_ui/config.html
@@ -158,11 +158,16 @@
                 }
 
                 if ( result['host_appengine_mode'] == 'gae' ) {
-                    $('#deploy-via-gae').parent().bootstrapSwitch('setState', true);
+                    $('#deploy-via-gae').parent().removeClass('switch-off');
+                    $('#deploy-via-gae').parent().addClass('switch-on');
+                    $('#deploy-via-gae').prop('checked', true);
                 }
 
                 if ( typeof(result['proxy_enable']) != 'undefined' && result['proxy_enable'] != 0 ) {
-                    $('#enable-proxy').parent().bootstrapSwitch('setState', true)
+                    $('#enable-proxy').parent().removeClass('switch-off');
+                    $('#enable-proxy').parent().addClass('switch-on');
+
+                    $('#enable-proxy').prop('checked', true);
                     $('#proxy-options').slideDown();
                 }
                 $('#proxy-type').val(result['proxy_type']);
@@ -171,7 +176,9 @@
                 $('#proxy-username').val(result['proxy_user']);
                 $('#proxy-password').val(result['proxy_passwd']);
                 if ( result['use_ipv6'] == 1 ) {
-                    $('#use-ipv6').parent().bootstrapSwitch('setState', true);
+                    $('#use-ipv6').parent().removeClass('switch-off');
+                    $('#use-ipv6').parent().addClass('switch-on');
+                    $('#use-ipv6').prop('checked', true);
                 }
             },
             error: function(){

--- a/gae_proxy/web_ui/scan_setting.html
+++ b/gae_proxy/web_ui/scan_setting.html
@@ -75,7 +75,10 @@
             dataType: 'JSON',
             success: function(result) {
                 if ( result['auto_adjust_scan_ip_thread_num'] != 0 ) {
-                    $( "#auto-adjust-scan-ip-thread-num").parent().bootstrapSwitch('setState', true);
+                    $( "#auto-adjust-scan-ip-thread-num").parent().removeClass('switch-off');
+                    $( "#auto-adjust-scan-ip-thread-num").parent().addClass('switch-on');
+
+                    $( "#auto-adjust-scan-ip-thread-num").prop('checked', true);
                 }
                 $('#scan-ip-thread-num').val(result['scan_ip_thread_num']);
             },

--- a/gae_proxy/web_ui/status.html
+++ b/gae_proxy/web_ui/status.html
@@ -544,10 +544,14 @@
             dataType: 'JSON',
             success: function(result) {
                 if ( result['show_detail'] != 0 ) {
-                    $( "#show-detail").parent().bootstrapSwitch('setState', true);
+                    $( "#show-detail").parent().removeClass('switch-off');
+                    $( "#show-detail").parent().addClass('switch-on');
+                    $( "#show-detail").prop('checked', true);
                     $( "#details" ).slideDown();
                 } else {
-                    $( "#show-detail").parent().bootstrapSwitch('setState', false);
+                    $( "#show-detail").parent().addClass('switch-off');
+                    $( "#show-detail").parent().removeClass('switch-on');
+                    $( "#show-detail").prop('checked', false);
                     $( "#details" ).slideUp();
                 }
             }

--- a/launcher/web_ui/config.html
+++ b/launcher/web_ui/config.html
@@ -148,25 +148,47 @@
             dataType: 'JSON',
             success: function(result) {
                 if ( result['auto_start'] != 0 ) {
-                    $( "#auto-start").parent().bootstrapSwitch('setState', true);
+                    $( "#auto-start").parent().removeClass('switch-off');
+                    $( "#auto-start").parent().addClass('switch-on');
+
+                    $( "#auto-start").prop('checked', true);
                 }
                 if ( result['popup_webui'] != 0 ) {
-                    $( "#popup-webui").parent().bootstrapSwitch('setState', true);
+                    $( "#popup-webui").parent().removeClass('switch-off');
+                    $( "#popup-webui").parent().addClass('switch-on');
+
+                    $( "#popup-webui").prop('checked', true);
                 }
                 if ( result['allow_remote_connect'] != 0 ) {
-                    $( "#allow-remote-connect").parent().bootstrapSwitch('setState', true);
+                    $( "#allow-remote-connect").parent().removeClass('switch-off');
+                    $( "#allow-remote-connect").parent().addClass('switch-on');
+
+                    $( "#allow-remote-connect").prop('checked', true);
                 }
                 if ( result['show_systray'] != 0 ) {
-                    $( "#show-systray").parent().bootstrapSwitch('setState', true);
+                    $( "#show-systray").parent().removeClass('switch-off');
+                    $( "#show-systray").parent().addClass('switch-on');
+
+                    $( "#show-systray").prop('checked', true);
                 }
                 if ( result['gae_proxy_enable'] != 0 ) {
-                    $( "#gae_proxy-enable").parent().bootstrapSwitch('setState', true);
+                    $( "#gae_proxy-enable").parent().removeClass('switch-off');
+                    $( "#gae_proxy-enable").parent().addClass('switch-on');
+
+
+                    $( "#gae_proxy-enable").prop('checked', true);
                 }
                 if ( result['php_enable'] != 0 ) {
-                    $( "#php-enable").parent().bootstrapSwitch('setState', true);
+                    $( "#php-enable").parent().removeClass('switch-off');
+                    $( "#php-enable").parent().addClass('switch-on');
+
+                    $( "#php-enable").prop('checked', true);
                 }
                 if ( result['x_tunnel_enable'] != 0 ) {
-                    $( "#x-tunnel-enable").parent().bootstrapSwitch('setState', true);
+                    $( "#x-tunnel-enable").parent().removeClass('switch-off');
+                    $( "#x-tunnel-enable").parent().addClass('switch-on');
+
+                    $( "#x-tunnel-enable").prop('checked', true);
                 }
                 $( "#language").val(result['language']);
                 $( "#check-update").val(result['check_update']);

--- a/php_proxy/web_ui/config.html
+++ b/php_proxy/web_ui/config.html
@@ -98,7 +98,10 @@
                 $('#php-password').val(result['php_password']);
 
                 if ( typeof(result['proxy_enable']) != 'undefined' && result['proxy_enable'] != 0 ) {
-                    $('#enable-front-proxy').parent().bootstrapSwitch('setState', true);
+                    $('#enable-front-proxy').parent().removeClass('switch-off');
+                    $('#enable-front-proxy').parent().addClass('switch-on');
+
+                    $('#enable-front-proxy').prop('checked', true);
                     $('#front-proxy-options').slideDown();
                 }
                 $('#proxy-host').val(result['proxy_host']);


### PR DESCRIPTION
This reverts commit e83a767c3329de63477dda1e31a6eb80bab2edc0.

之前的想法错了，bootstrapSwitch会触发change事件。
[据说](https://github.com/nostalgiaz/bootstrap-switch/issues/123)第三个参数设true可以跳过，但change事件经测不能跳过。试了`.on('switchChange.bootstrapSwitch'`等事件，均无法正常触发。
最后发现当前库的版本可以用`.bootstrapSwitch('setState'`事件，并且似乎始终会跳过bootstrapSwitch事件。但多处重构后还是有很多莫名失效，调试许久无果。还是恢复原来的办法吧。