### PR TITLE
Allow import_windows_ca failed, user may reject to UAC

### DIFF
--- a/gae_proxy/local/cert_util.py
+++ b/gae_proxy/local/cert_util.py
@@ -319,7 +319,10 @@ class CertUtil(object):
                 #    return -1
 
                 import win32elevate
-                win32elevate.elevateAdminRun(os.path.abspath(__file__))
+                try:
+                    win32elevate.elevateAdminRun(os.path.abspath(__file__))
+                except Exception as e:
+                    xlog.warning('CertUtil.import_windows_ca failed: %r', e)
                 return True
             else:
                 CertUtil.win32_notify(msg=u'已经导入GoAgent证书，请重启浏览器.', title=u'Restart browser need.')


### PR DESCRIPTION
如果不try，在新data目录时，如果用户拒绝UAC（导入新证书），代理和网页界面端口不会开始服务，只有扫描IP的组件在运行。应该允许拒绝UAC导入，然后手动操作（下载证书和处理，或者只是看界面和扫描IP等）。未将整体纳入，未纳入import_linux_firefox_ca等同类函数，因为未考量其他执行失败的情况。