### PR TITLE
Correct shortcut target to pythonw.exe in create_shortcut.js

### DIFF
--- a/launcher/create_shortcut.js
+++ b/launcher/create_shortcut.js
@@ -2,7 +2,7 @@
 function CreateShortcut()
 {
    wsh = new ActiveXObject('WScript.Shell');
-   target_path = '"' + wsh.CurrentDirectory + '\\..\\python3\\python.exe"';
+   target_path = '"' + wsh.CurrentDirectory + '\\..\\python3\\pythonw.exe"';
    icon_path = wsh.CurrentDirectory + '\\web_ui\\favicon.ico';
 
 


### PR DESCRIPTION
仅py3分支的问题。应该创建无窗口的pythonw，不然启动后有一个最小化的控制台窗口。`main`中的`    ctypes.windll.user32.ShowWindow(ctypes.windll.kernel32.GetConsoleWindow(), 0)` 好像没起作用，`show_control_web`中的倒是有效，单击托盘图标可以触发隐藏。