### PR TITLE
[WIP] Specify system python in start.command

### DIFF
--- a/start.command
+++ b/start.command
@@ -1,2 +1,3 @@
+#!/bin/bash
 cd "$(dirname "$0")"
-/usr/bin/env python2.7 launcher/start.py
+/usr/bin/python2.7 launcher/start.py


### PR DESCRIPTION
Resolves #2622 where python installed from Anaconda overrides OS X built-in python.

**Do not merge** before fixing #2206 (Autoupdate drops execute permission of start.command)