### PR TITLE
Add `import urllib`

### DIFF
--- a/gae_proxy/local/gae_handler.py
+++ b/gae_proxy/local/gae_handler.py
@@ -58,6 +58,7 @@ import ssl
 import httplib
 import Queue
 import urlparse
+import urllib
 import threading
 
 


### PR DESCRIPTION
urllib is used in [line 455](https://github.com/XX-net/XX-Net/blob/master/gae_proxy/local/gae_handler.py#L455), but not imported