### PR TITLE
fix lost ip quickly when network not available

### DIFF
--- a/gae_proxy/local/check_ip.py
+++ b/gae_proxy/local/check_ip.py
@@ -98,9 +98,9 @@ def connect_ssl(ip, port=443, timeout=5, openssl_context=None, check_cert=True):
     time_handshaked = time.time()
 
     # report network ok
-    check_local_network.network_stat = "OK"
-    check_local_network.last_check_time = time_handshaked
-    check_local_network.continue_fail_count = 0
+    #check_local_network.network_stat = "OK"
+    #check_local_network.last_check_time = time_handshaked
+    #check_local_network.continue_fail_count = 0
 
     cert = ssl_sock.get_peer_certificate()
     if not cert:


### PR DESCRIPTION
python3 版本的 check_ip 中重置 network_stat、last_check_time、continue_fail_count 的功能，在断网的情况下会不断更新使 _simple_check_worker 不能被激活，从而导致大量IP失效，只不过失效的时候不会更新 good_ip.txt，但是重新联网依然会更新到 good_ip.txt ，此现象只在python3版出现，python2不会。