### PR TITLE
更改Python版本检测方法&修正xx_net.sh中的一个小错误

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,9 +2,10 @@
 
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPTPATH
-
-if hash python2 2>/dev/null; then
-    python2 launcher/start.py
+if python -V | grep -q "Python 3" ;then
+    PYTHON="/usr/bin/python2"
 else
-    python launcher/start.py
+    PYTHON="python"
 fi
+
+${PYTHON} launcher/start.py

--- a/xx_net.sh
+++ b/xx_net.sh
@@ -20,24 +20,22 @@ set -e
 PACKAGE_NAME=xx_net
 PACKAGE_DESC="xx_net proxy server"
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:${PATH}
+if python -V | grep -q "Python 3" ;then
+    PYTHON="/usr/bin/python2"
+else
+    PYTHON="python"
+fi
 
 start() {
     echo -n "Starting ${PACKAGE_DESC}: "
     if hash python2 2>/dev/null; then
-        nohup python2 launcher/start.py 2>&1 | /usr/bin/logger -t ${PACKAGE_NAME} &
-    else
-        nohup python launcher/start.py 2>&1 | /usr/bin/logger -t ${PACKAGE_NAME} &
-    fi
+        nohup "${PYTHON}" launcher/start.py 2>&1 | /usr/bin/logger -t ${PACKAGE_NAME} &
     echo "${PACKAGE_NAME}."
 }
 
 stop() {
     echo -n "Stopping ${PACKAGE_DESC}: "
-    if hash python2 2>/dev/null; then
-        kill -9 `ps aux | grep 'python2 launcher/start.py' | grep -v grep | awk '{print $2}'` || true
-    else
-        kill -9 `ps aux | grep 'python launcher/start.py' | grep -v grep | awk '{print $2}'` || true
-    fi
+    kill -9 `ps aux | grep ${PYTHON} 'launcher/start.py' | grep -v grep | awk '{print $2}'` || truei
     echo "${PACKAGE_NAME}."
 }
 
@@ -59,7 +57,7 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 # `readlink -f` won't work on Mac, this hack should work on all systems.
-cd $(python -c "import os; print os.path.dirname(os.path.realpath('$0'))")
+cd $("${PYTHON}" -c "import os; print os.path.dirname(os.path.realpath('$0'))")
 
 case "$1" in
     # If no arg is given, start the goagent.


### PR DESCRIPTION
修复python命令默认为启动Python3时xx_net.sh第60行处报错；
并修改为通过Python -V来检测Python版本，因为部分情况下通过hash不一定能正常判断Python版本