### PR TITLE
修复文件夹带空格时不能运行的问题

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,3 +1,3 @@
 SET PYTHONPATH=
-%~dp0start.vbs console
+"%~dp0%start.vbs" console
 


### PR DESCRIPTION
修复存放文件夹带空格/特殊字符时，不能启动的问题

问题如下：
D:\Program Files (x86)\XX-Net>start.bat

D:\Program Files (x86)\XX-Net>SET PYTHONPATH=

D:\Program Files (x86)\XX-Net>D:\Program Files (x86)\XX-Net\start.vbs console
'D:\Program' is not recognized as an internal or external command,
operable program or batch file.