### PR TITLE
修复2.X自动更新（依赖 #2944）

### DIFF
--- a/code/default/launcher/post_update.py
+++ b/code/default/launcher/post_update.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import re
+import stat
+import shutil
+
+current_path = os.path.dirname(os.path.abspath(__file__))
+root_path = os.path.abspath( os.path.join(current_path, os.pardir))
+top_path = os.path.abspath(os.path.join(root_path, os.pardir, os.pardir))
+
+from instances import xlog
+import config
+
+def older_or_equal(version, reference_version):
+    p = re.compile(r'([0-9]+)\.([0-9]+)\.([0-9]+)')
+    m1 = p.match(version)
+    m2 = p.match(reference_version)
+    v1 = map(int, map(m1.group, [1,2,3]))
+    v2 = map(int, map(m2.group, [1,2,3]))
+    return v1 <= v2
+
+def run(last_run_version):
+    if config.get(["modules", "launcher", "auto_start"], 0):
+        import autorun
+        autorun.enable()
+    
+    if older_or_equal(last_run_version, '3.0.4'):
+        xlog.info("migrating to 3.0.5")
+        for filename in os.listdir(top_path):
+            filepath = os.path.join(top_path, filename)
+            if os.path.isfile(filepath):
+                if sys.platform != 'win32' and filename == 'xxnet':
+                    st = os.stat(filepath)
+                    os.chmod(filepath, st.st_mode | stat.S_IEXEC)
+                if not filename.startswith('.') and filename not in ['README.md', 'xxnet', 'xxnet.bat', 'xxnet.vbs']:
+                    os.remove(filepath)
+            else:
+                if not filename.startswith('.') and filename not in ['code', 'data']:
+                    shutil.rmtree(filepath)

--- a/code/default/launcher/start.py
+++ b/code/default/launcher/start.py
@@ -101,11 +101,19 @@ def main():
         __file__ = getattr(os, 'readlink', lambda x: x)(__file__)
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    xlog.info("start XX-Net %s", update_from_github.current_version())
+    current_version = update_from_github.current_version()
+
+    xlog.info("start XX-Net %s", current_version)
 
     web_control.confirm_xxnet_exit()
 
     setup_win_python.check_setup()
+
+    last_run_version = config.get(["modules", "launcher", "last_run_version"], "0.0.0")
+    if last_run_version != current_version:
+        import post_update
+        post_update.run(last_run_version)
+        config.set(["modules", "launcher", "last_run_version"], current_version)
 
     module_init.start_all_auto()
 

--- a/code/default/launcher/update_from_github.py
+++ b/code/default/launcher/update_from_github.py
@@ -181,11 +181,13 @@ def overwrite(xxnet_version, xxnet_unzip_path):
                 dst_file = os.path.join(top_path, target_relate_path, filename)
                 if not os.path.isfile(dst_file) or hash_file_sum(src_file) != hash_file_sum(dst_file):
                     xlog.info("copy %s => %s", src_file, dst_file)
-                    shutil.copy(src_file, dst_file)
-
-                st = os.stat(src_file)
-                if st.st_mode & stat.S_IEXEC:
-                    os.chmod(dst_file, st.st_mode)
+                    if sys.platform != 'win32' and os.path.isfile(dst_file):
+                        st = os.stat(dst_file)
+                        shutil.copy(src_file, dst_file)
+                        if st.st_mode & stat.S_IEXEC:
+                            os.chmod(dst_file, st.st_mode)
+                    else:
+                        shutil.copy(src_file, dst_file)
 
     except Exception as e:
         xlog.warn("update over write fail:%r", e)

--- a/launcher/start.py
+++ b/launcher/start.py
@@ -1,0 +1,9 @@
+# Required for auto-update from 2.x, this folder will be automatically deleted once migration to 3.0 is completed.
+
+import os, sys
+import subprocess
+
+current_path = os.path.dirname(os.path.abspath(__file__))
+start_sript = os.path.abspath(os.path.join(current_path, os.pardir, "code", "default", "launcher", "start.py"))
+
+subprocess.Popen([sys.executable, start_sript])


### PR DESCRIPTION
加入更新后自动迁移功能，在启动时检测上次运行的版本，如果小于目前版本则触发迁移。

迁移逻辑在`post_update.py`中，目前会给`xxnet`加执行权限，删除无用文件和目录，并重新配置开机自动启动（解决Windows下自启老版本的问题）。

经简单测试能从2.3.0和3.0.4自动升级至此版本。如果进一步测试能通过，可以把下载页面移回主页。

本PR依赖于#2944。