### PR TITLE
顶层添加文件清单以便迁移

### DIFF
--- a/code/default/launcher/post_update.py
+++ b/code/default/launcher/post_update.py
@@ -23,17 +23,33 @@ def run(last_run_version):
     if config.get(["modules", "launcher", "auto_start"], 0):
         import autorun
         autorun.enable()
-    
-    if older_or_equal(last_run_version, '3.0.4'):
-        xlog.info("migrating to 3.0.5")
+
+    dirs = []
+    files = []
+    unix_exec = None
+
+    with open(os.path.join(top_path, 'manifest.txt')) as f:
+        for line in f:
+            filename = line.rstrip('\n')[2:]
+            if line.startswith('D '):
+                dirs.append(filename)
+            if line.startswith('F '):
+                files.append(filename)
+            if line.startswith('X '):
+                unix_exec = filename
+                files.append(filename)
+
+#    if older_or_equal(last_run_version, '3.0.4'):
+#        xlog.info("migrating to latest version")
+    if dirs and files and unix_exec:
         for filename in os.listdir(top_path):
             filepath = os.path.join(top_path, filename)
             if os.path.isfile(filepath):
-                if sys.platform != 'win32' and filename == 'xxnet':
+                if sys.platform != 'win32' and filename == unix_exec:
                     st = os.stat(filepath)
                     os.chmod(filepath, st.st_mode | stat.S_IEXEC)
-                if not filename.startswith('.') and filename not in ['README.md', 'xxnet', 'xxnet.bat', 'xxnet.vbs']:
+                if not filename.startswith('.') and filename not in files:
                     os.remove(filepath)
             else:
-                if not filename.startswith('.') and filename not in ['code', 'data']:
+                if not filename.startswith('.') and filename not in dirs:
                     shutil.rmtree(filepath)

--- a/manifest.txt
+++ b/manifest.txt
@@ -1,0 +1,11 @@
+# Files not on this list (including itself) will be deleted
+# 不在此列表上的文件（包括本文件）会被删除
+
+# D: Directory, F: File, X: Unix Executable
+
+D data
+D code
+F README.md
+F xxnet.bat
+F xxnet.vbs
+X xxnet


### PR DESCRIPTION
目前写死在`post_update.py`中的文件列表可能导致以后升级误删文件，将文件列表写在顶层以方便更新。