### PR TITLE
更新时自动删除launcher文件夹（#2987 的备选方案）

### DIFF
--- a/code/default/launcher/post_update.py
+++ b/code/default/launcher/post_update.py
@@ -23,9 +23,11 @@ def run(last_run_version):
     if config.get(["modules", "launcher", "auto_start"], 0):
         import autorun
         autorun.enable()
-    
+
+    shutil.rmtree(os.path.join(top_path, 'launcher')) # launcher is for auto-update from 2.X
+
     if older_or_equal(last_run_version, '3.0.4'):
-        xlog.info("migrating to 3.0.5")
+        xlog.info("migrating to 3.0.5+")
         for filename in os.listdir(top_path):
             filepath = os.path.join(top_path, filename)
             if os.path.isfile(filepath):

--- a/launcher/DO_NOT_PUT_ANYTHING_HERE
+++ b/launcher/DO_NOT_PUT_ANYTHING_HERE
@@ -1,0 +1,2 @@
+This folder will be automatically deleted!
+DO NOT put anything useful here.


### PR DESCRIPTION
#2987 是此问题的彻底解决方案，但如果不希望顶层添加文件，这个方法也能保证每次更新自动删除launcher文件夹。

这种方法的坏处是如果以后增减顶层文件而不修改`post_update.py`，则从3.0.4或更早版本升级上来时会出问题。