### PR TITLE
Check whether python-openssl is installed when startup.

### DIFF
--- a/start
+++ b/start
@@ -39,12 +39,12 @@ os_name=`uname -s`
 # Install Packages
 echo 'Install python-openssl and libnss3-tools for your system'
 if [ $os_name = 'Linux' ]; then
-    if [ -f /etc/debian_version ]; then
+    if [ `which apt-get | wc -l` != 0 ]; then
         if [ `dpkg-query -l | grep python-openssl | wc -l` == 0 ]; then
             sudo apt-get install -y python-openssl
         fi
-    elif [ -f /etc/redhat-release ]; then
-        if [ `yum -q list installed pyOpenSSL | wc -l` == 0 ]; then
+    elif [ `which yum | wc -l` != 0 ]; then
+        if [ `yum -q list installed | grep pyOpenSSL | wc -l` == 0 ]; then
             sudo yum install -y pyOpenSSL
         fi
     # Do Someting for ArchLinux

--- a/start
+++ b/start
@@ -11,14 +11,14 @@ fi
 
 
 if [ -f code/version.txt ]; then
-  VERSION=`cat code/version.txt`
+    VERSION=`cat code/version.txt`
 else
-  VERSION="default"
+    VERSION="default"
 fi
 
 
 if [ ! -d "code/$VERSION" ]; then
-  VERSION="default"
+    VERSION="default"
 fi
 echo "XX-Net version:$VERSION"
 
@@ -36,10 +36,29 @@ function launchWithHungup() {
 # get operating system name
 os_name=`uname -s`
 
-# Darwin for os x
-if [ $os_name = 'Darwin' ];then
-	PYTHON="/usr/bin/python2.7"
-	launchWithNoHungup
+# Install Packages
+echo 'Install python-openssl and libnss3-tools for your system'
+if [ $os_name = 'Linux' ]; then
+    if [ -f /etc/debian_version ]; then
+        if [ `dpkg-query -l | grep python-openssl | wc -l` == 0 ]; then
+            sudo apt-get install -y python-openssl
+        fi
+    elif [ -f /etc/redhat-release ]; then
+        if [ `yum -q list installed pyOpenSSL | wc -l` == 0 ]; then
+            sudo yum install -y pyOpenSSL
+        fi
+    # Do Someting for ArchLinux
+    # Do Someting for OpenSUSE
+    # Do Someting for OpenWRT
+    fi
+# elif [ $os_name = 'Darwin' ]; then
+    # Do Someting for Mac
+fi
+
+# Start Application
+if [ $os_name = 'Darwin' ]; then
+    PYTHON="/usr/bin/python2.7"
+    launchWithNoHungup
 else
-	launchWithHungup
+    launchWithHungup
 fi


### PR DESCRIPTION
解决了评论中提到的问题
https://github.com/XX-net/XX-Net/issues/3040#issuecomment-215039486

目前测试的操作系统有:

Ubuntu 16.04, 10.04; Cent OS 7

Debian晚些时候我会测试，应该和Ubuntu是一样的。

Mac上的安装可能需要借助于`brew`。
其他Linux发行版我晚些时候再完善，也请小伙伴们一起帮忙完善。
