### PR TITLE
Fix autorun on Mac

### DIFF
--- a/code/default/launcher/autorun.py
+++ b/code/default/launcher/autorun.py
@@ -101,6 +101,7 @@ elif sys.platform == 'darwin':
 	<key>ProgramArguments</key>
 	<array>
 	  <string>%s</string>
+	  <string>-hungup</string>
 	</array>
 
 	<key>RunAtLoad</key>

--- a/code/default/launcher/start.py
+++ b/code/default/launcher/start.py
@@ -126,6 +126,7 @@ def main():
         import post_update
         post_update.run(last_run_version)
         config.set(["modules", "launcher", "last_run_version"], current_version)
+        config.save()
 
     module_init.start_all_auto()
 

--- a/start
+++ b/start
@@ -63,7 +63,7 @@ if [ $os_name = 'Linux' ]; then
 fi
 
 # Start Application
-if [ $os_name = 'Darwin' ]; then
+if [ $os_name = 'Darwin' ] && ! [ "$1" = '-hungup' ]; then
     PYTHON="/usr/bin/python2.7"
     launchWithNoHungup
 else


### PR DESCRIPTION
自动启动时不能忽略hungup信号

修复#3187 #3163