### PR TITLE
Improve installation script for linux

### DIFF
--- a/start
+++ b/start
@@ -36,27 +36,40 @@ function launchWithHungup() {
 # get operating system name
 os_name=`uname -s`
 
+# check command avalibility
+function has_command() {
+    command -v $1 > /dev/null
+}
+
 # Install Packages
 if [ $os_name = 'Linux' ]; then
-    echo 'Install python-openssl and libnss3-tools for your system'
-    if [ `which apt-get | wc -l` != 0 ]; then
-        if [ `dpkg-query -l | grep python-openssl | wc -l` == 0 ]; then
-            sudo apt-get install -y python-openssl
+    if ! python -c 'import OpenSSL' 2> /dev/null; then
+        echo 'You have not installed pyOpenSSL yet.'
+        if [[ $- == *i* ]]; then
+            # interactive shell
+            echo 'Installing pyOpenSSL for your system... Please type in your password if requested'
+            if has_command zypper; then
+                # openSUSE
+                sudo zypper in -y python-pyOpenSSL
+            elif has_command apt-get; then
+                # Debian or Debian-like
+                sudo apt-get install -y python-openssl
+            elif has_command dnf; then
+                # Fedora
+                sudo dnf install -y pyOpenSSL
+            elif has_command yum; then
+                # RedHat
+                sudo yum install -y pyOpenSSL
+            elif has_command pacman; then
+                # ArchLinux
+                sudo pacman -S --noconfirm openssl python2-pyopenssl
+            # Do Someting for OpenWRT
+            fi
+        else
+            # non-interactive shell
+            echo 1>&2 'Please install pyOpenSSL.'
+            exit 1
         fi
-    elif [ `which dnf | wc -l` != 0 ]; then
-        if [ `dnf -q list installed | grep pyOpenSSL | wc -l` == 0 ]; then
-            sudo dnf install -y pyOpenSSL
-        fi
-    elif [ `which yum | wc -l` != 0 ]; then
-        if [ `yum -q list installed | grep pyOpenSSL | wc -l` == 0 ]; then
-            sudo yum install -y pyOpenSSL
-        fi
-    elif [ `which pacman | wc -l` != 0 ]; then
-        if [ `pacman -Q | grep python2-pyopenssl | wc -l` == 0 ]; then
-            sudo pacman -S --noconfirm openssl python2-pyopenssl
-        fi
-    # Do Someting for OpenSUSE
-    # Do Someting for OpenWRT
     fi
 elif [ $os_name = 'Darwin' ]; then
     if [ `python -c 'import OpenSSL; print(OpenSSL.SSL.OPENSSL_VERSION_NUMBER > 0x1000200)' 2> /dev/null | grep True | wc -l` != 1 ]; then


### PR DESCRIPTION
Add script for openSUSE
only auto-install in interactive shell

把 openSUSE 的检测改到最前面是因为 openSUSE 自带了 apt-get 和 aptitude 两个 perl 脚本来转换并兼容部分 deb 系的命令……这样如果先检测 apt-get 的话可能有问题（不过我改了检测 pyOpenSSL 是否安装的方法之后目前顺序貌似不重要）。