### PR TITLE
Add:create a startup file for ubuntu

### DIFF
--- a/start
+++ b/start
@@ -81,6 +81,36 @@ elif [ $os_name = 'Darwin' ]; then
     fi
 fi
 
+# create a desktop startup file when the distro is Ubuntu.
+function createDesktopStartup() {
+    DESKFILE='start.desktop'
+    if [[ -f $DESKFILE ]]; then
+        echo "$DESKFILE already exists"
+        return
+    else
+        echo "$DESKFILE does not exist,ctreat a new one"
+    fi
+    NAME="XX-Net"
+    EXEC="$SCRIPTPATH/start > /dev/null"
+    ICON="$SCRIPTPATH/code/default/launcher/web_ui/favicon.ico"
+    TERMINAL="false"
+    TYPE="Application"
+    CATEGORIES="Development"
+    echo "[Desktop Entry]" >> $DESKFILE
+    echo "Version=$VERSION" >> $DESKFILE
+    echo "Name=$NAME" >> $DESKFILE
+    echo "Exec=$EXEC" >> $DESKFILE
+    echo "Terminal=$TERMINAL" >> $DESKFILE
+    echo "Icon=$ICON" >> $DESKFILE
+    echo "Type=$TYPE" >> $DESKFILE
+    echo "Categories=$CATEGORIES" >> $DESKFILE
+}
+
+DIS=`cat /etc/issue`
+if [[ $DIS == *Ubuntu* ]]; then
+    createDesktopStartup
+fi
+
 # Start Application
 if [ $os_name = 'Darwin' ] && ! [ "$1" = '-hungup' ]; then
     launchWithNoHungup

--- a/start
+++ b/start
@@ -83,8 +83,8 @@ fi
 
 # create a desktop startup file when the distro is Ubuntu.
 function createDesktopStartup() {
-    DESKFILE='start.desktop'
-    if [[ -f $DESKFILE ]]; then
+    DESKFILE='XX-Net.desktop'
+    if [[ -f $DESKFILE ]]; then 
         echo "$DESKFILE already exists"
         return
     else
@@ -104,6 +104,16 @@ function createDesktopStartup() {
     echo "Icon=$ICON" >> $DESKFILE
     echo "Type=$TYPE" >> $DESKFILE
     echo "Categories=$CATEGORIES" >> $DESKFILE
+
+    chmod 744 $DESKFILE
+    DESKDIR=~/Desktop/
+    cp $DESKFILE $DESKDIR
+
+    if [[ -d $DESKDIR ]]; then
+        cp $DESKFILE $DESKDIR
+    else
+        echo "$DESKDIR does not exist"
+    fi
 }
 
 DIS=`cat /etc/issue`


### PR DESCRIPTION
在start脚本启动时，创建了一个start.desktop文件，将这个文件拖入启动栏，就可以通过点击启动栏图标启动软件。
适用于ubuntu系统。