### PR TITLE
部署服务端的时候不再修改 RC4 密码

### DIFF
--- a/code/default/gae_proxy/server/uploader.bat
+++ b/code/default/gae_proxy/server/uploader.bat
@@ -1,1 +1,1 @@
-..\..\python27\1.0\python.exe uploader.py %1
+..\..\python27\1.0\python.exe uploader.py %1 %2 %3 %4 %5 %6 %7 %8 %9

--- a/code/default/gae_proxy/server/uploader.py
+++ b/code/default/gae_proxy/server/uploader.py
@@ -137,7 +137,7 @@ def update_rc4_password(rc4_password):
             logging.info('Setting in the %s password failed!' % file_name)
 
 
-def uploads(appids, rc4_password=""):
+def uploads(appids, rc4_password):
     update_rc4_password(rc4_password)
 
     clean_cookie_file()
@@ -183,21 +183,35 @@ def uploads(appids, rc4_password=""):
 
 def main():
     if len(sys.argv) < 2:
-        logging.info("Usage: uploader.py <appids> [-debug]")
+        logging.info("Usage: uploader.py <appids> [-debug] [-password rc4_password]")
         input_line = " ".join(sys.argv)
         logging.info("input err: %s " % input_line)
         logging.info("== END ==")
         exit()
 
     appids = sys.argv[1]
-    if len(sys.argv) > 2 and sys.argv[2] == "-debug":
-        logger.setLevel(logging.DEBUG)
-        logging.info("enable debug logging")
+    rc4_password = "";
+
+    if len(sys.argv) > 2:
+        i = 2
+        while i < len(sys.argv):
+            if sys.argv[i] == "-debug":
+                logger.setLevel(logging.DEBUG)
+                logging.info("enable debug logging")
+            elif sys.argv[i] == "-password":
+                i += 1
+                if i < len(sys.argv):
+                    rc4_password = sys.argv[i]
+                logging.info("use rc4_password: %s" % rc4_password)
+            else:
+                logging.info("unknow argv: %s" % sys.argv[i])
+
+            i += 1
 
     os.environ['HTTPS_PROXY'] = 'http://127.0.0.1:8087'
     logging.info("set proxy to http://127.0.0.1:8087")
 
-    uploads(appids)
+    uploads(appids, rc4_password)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
因为现在部署页面已经没有了密码设置，而且 uploader.py 里也没法设置密码，现在的代码会导致根本无法设置 RC4 密码。
uploader.py 会在部署之前强行将 gae.py 与 wsgi.py 的密码清空，而 uploader.py 自己也不支持设置密码，所以现在除非修改 uploader.py 否则根本没办法设置 RC4 密码。
因此这里把修改 RC4 密码的代码直接删掉了。
