### PR TITLE
flush when saving good_ip.txt, fix #3408

### DIFF
--- a/code/default/gae_proxy/local/google_ip.py
+++ b/code/default/gae_proxy/local/google_ip.py
@@ -196,6 +196,7 @@ class IpManager():
                             property['handshake_time'],
                             property['fail_times'],
                             property['down_fail']) )
+                fd.flush()
 
             self.iplist_need_save = False
         except Exception as e:


### PR DESCRIPTION
遇到过多次#3408的问题。这大概能解决。参考了 https://github.com/XX-net/XX-Net/blob/6f054189250462317854d554ace1987ebb833053/code/default/gae_proxy/local/scan_ip_log.py#L52