### PR TITLE
2016.06.05 Small fixes

### DIFF
--- a/code/default/gae_proxy/local/check_local_network.py
+++ b/code/default/gae_proxy/local/check_local_network.py
@@ -77,7 +77,7 @@ def report_network_fail():
     last_check_time = time.time()
 
     if continue_fail_count > 10:
-        # network_stat = "unkown"
+        # network_stat = "unknown"
         xlog.debug("report_connect_fail continue_fail_count:%d", continue_fail_count)
         triger_check_network()
 

--- a/code/default/gae_proxy/local/google_ip.py
+++ b/code/default/gae_proxy/local/google_ip.py
@@ -644,7 +644,7 @@ class IpManager():
         self.scan_thread_lock.acquire()
         self.scan_thread_count -= 1
         self.scan_thread_lock.release()
-        xlog.info("scan_ip_worker exit")
+        #xlog.info("scan_ip_worker exit")
 
     def search_more_google_ip(self):
         if config.USE_IPV6:

--- a/code/default/gae_proxy/web_ui/status.html
+++ b/code/default/gae_proxy/web_ui/status.html
@@ -418,7 +418,7 @@
                     return updateProperty('#noob-info', '{{ _( "You are using public APPID. You are recommended to <a href=\"https://github.com/XX-net/XX-Net/wiki/Register-Google-appid\" target=\"_blank\">deploy your own APPID</a>" ) }}', 'hard');
                 }
 
-                return updateProperty('#noob-info', "XX-Net " + result['xxnet_version'] + '{{ _( ", Everything is OK. Welcome to the FREE Internet. " ) }}', 'fluent');
+                return updateProperty('#noob-info', "XX-Net " + result['xxnet_version'].trim() + '{{ _( ", Everything is OK. Welcome to the FREE Internet. " ) }}', 'fluent');
 
             },
             error: function(result) {

--- a/code/default/launcher/post_update.py
+++ b/code/default/launcher/post_update.py
@@ -12,12 +12,16 @@ from instances import xlog
 import config
 
 def older_or_equal(version, reference_version):
-    p = re.compile(r'([0-9]+)\.([0-9]+)\.([0-9]+)')
-    m1 = p.match(version)
-    m2 = p.match(reference_version)
-    v1 = map(int, map(m1.group, [1,2,3]))
-    v2 = map(int, map(m2.group, [1,2,3]))
-    return v1 <= v2
+    try:
+        p = re.compile(r'([0-9]+)\.([0-9]+)\.([0-9]+)')
+        m1 = p.match(version)
+        m2 = p.match(reference_version)
+        v1 = map(int, map(m1.group, [1,2,3]))
+        v2 = map(int, map(m2.group, [1,2,3]))
+        return v1 <= v2
+    except:
+        xlog.warn("older_or_equal fail: %s, %s" % (version, reference_version)) # e.g. "get_version_fail" when post_update.run(last_run_version), "last_run_version" in \data\launcher\config.yaml
+        return False # is not older
 
 def run(last_run_version):
     if config.get(["modules", "launcher", "auto_start"], 0):


### PR DESCRIPTION
"scan_ip_worker exit" 在减少线程数时会大量输出，用途不明。

削除行尾换行造成的一个空格。

避免上次运行版本格式错误时无法启动。