### PR TITLE
Change default validity for generated .cert file to 10 years

### DIFF
--- a/code/default/gae_proxy/local/cert_util.py
+++ b/code/default/gae_proxy/local/cert_util.py
@@ -158,6 +158,8 @@ class CertUtil(object):
     ca_certdir = os.path.join(data_path, 'certs')
     ca_digest = 'sha256'
     ca_lock = threading.Lock()
+    ca_validity_years = 10
+    ca_validity = 24 * 60 * 60 * 365 * ca_validity_years
 
     @staticmethod
     def create_ca():
@@ -177,7 +179,7 @@ class CertUtil(object):
         ca.set_version(2)
         ca.set_serial_number(0)
         ca.gmtime_adj_notBefore(0)
-        ca.gmtime_adj_notAfter(24 * 60 * 60 * 3652)
+        ca.gmtime_adj_notAfter(CertUtil.ca_validity)
         ca.set_issuer(req.get_subject())
         ca.set_subject(req.get_subject())
         ca.set_pubkey(req.get_pubkey())
@@ -239,7 +241,7 @@ class CertUtil(object):
         except OpenSSL.SSL.Error:
             cert.set_serial_number(int(time.time()*1000))
         cert.gmtime_adj_notBefore(-600) #avoid crt time error warning
-        cert.gmtime_adj_notAfter(60 * 60 * 24 * 365)
+        cert.gmtime_adj_notAfter(CertUtil.ca_validity)
         cert.set_issuer(ca.get_subject())
         cert.set_subject(req.get_subject())
         cert.set_pubkey(req.get_pubkey())


### PR DESCRIPTION
I had an `certification expired` issue yesterday,  and found it's due to the default validity of .cert is 1 year, maybe it's better to set it to 10 years. So I fork & changed a little code.

The static variable `ca_validity` from class `CertUtil` defines how many years, you can change that if you think there could be a number better than 10 years, thanks.

refer: https://github.com/XX-net/XX-Net/issues/4126
