### PR TITLE
Support reverse rules for proxy by specifying `proxy.hosts`

### DIFF
--- a/code/default/gae_proxy/local/config.py
+++ b/code/default/gae_proxy/local/config.py
@@ -56,6 +56,9 @@ class Config(object):
             self.GAE_APPIDS = []
         self.GAE_PASSWORD = self.CONFIG.get('gae', 'password').strip()
 
+        self.ONLYHOSTS = [x.strip() for x in self.CONFIG.get('proxy', 'hosts').split("|")]
+        xlog.info("Only these hosts will proxy: %s", self.ONLYHOSTS)
+
         fwd_endswith = []
         fwd_hosts = []
         direct_endswith = []

--- a/code/default/gae_proxy/local/proxy_handler.py
+++ b/code/default/gae_proxy/local/proxy_handler.py
@@ -173,11 +173,13 @@ class GAEProxyHandler(simple_http_server.HttpServerHandler):
                     or s in self.local_names:
                 print s
                 return True
-            if s.startswith('gcr.io') \
-                    or s.endswith('google.com') \
-                    or s.endswith('googleapis.com'):
-                return False
-        return True
+            for h in config.ONLYHOSTS:
+                if s.endswith(h):
+                    return False
+        if len(config.ONLYHOSTS) > 0:
+            return True
+        else:
+            return False
 
     def do_METHOD(self):
         touch_active()

--- a/code/default/gae_proxy/local/proxy_handler.py
+++ b/code/default/gae_proxy/local/proxy_handler.py
@@ -112,7 +112,6 @@ class GAEProxyHandler(simple_http_server.HttpServerHandler):
             path = '?'.join([self.parsed_url[2], self.parsed_url[4]])
         else:
             path = self.parsed_url[2]
-        xlog.warn("here we go")
         content, status, response = http_client.request(self.command, path, request_headers, payload)
         if not status:
             xlog.warn("forward_local fail: %d, command: %s, path: %s, headers: %s, payload: %s, response: %s",


### PR DESCRIPTION
In some situations, you may only want specified hosts accross the gae proxy but others not.

For example, you are running your docker cluster but some registries required can not be accessed normally. In this case, you can force all your docker daemon network data flowing through such proxies.

In other words, you can not decide which registry will be accessed through real proxy and which not. The only thing you can do is accessing all these registries through your gae proxy or not.

If you have this patch, you can configure these hosts and make them through your proxy but rest not. As following configuration in your `config.ini`:

    [proxy]
    hosts = gcr.io|google.com|googleapis.com

From this point, only these hosts will through your gae proxy but others not.

How about if I do not specified this option?

Nothing, your `XX-Net` acts no difference.