### PR TITLE
add param 'hosts =' to avoid error on start

### DIFF
--- a/code/default/gae_proxy/local/proxy.ini
+++ b/code/default/gae_proxy/local/proxy.ini
@@ -86,6 +86,7 @@ host = 127.0.0.1
 port = 8888
 user =
 passwd =
+hosts =
 
 
 [google_ip]


### PR DESCRIPTION
Simple fix for the issue described in following issues:
https://github.com/XX-net/XX-Net/issues/4731
https://github.com/XX-net/XX-Net/issues/4712

So that to avoid users to modify the file by hand.