### PR TITLE
Fix issue #3766.

### DIFF
--- a/code/default/gae_proxy/local/check_local_network.py
+++ b/code/default/gae_proxy/local/check_local_network.py
@@ -185,7 +185,7 @@ def _check_ipv6_host(host):
 
 
 def check_ipv6():
-    hosts = ["www.6rank.edu.cn", "v6.testmyipv6.com", ]
+    hosts = ["bt.neu6.edu.cn", "v6.ipv6-test.com", "ipv6.test-ipv6.jp"]
     for host in hosts:
         if _check_ipv6_host(host):
             return True


### PR DESCRIPTION
之前的两个检测IPv6的网址无法正常打开，遂替换为：

- 六维空间: `bt.neu6.edu.cn`
- DragonLab实验室: `www.cernet2.net`

替换的网址满足条件: DNS解析后仅返回IPv6地址.