### PR TITLE
Fix installtion script for OpenSSL in Linux.

### DIFF
--- a/start
+++ b/start
@@ -43,32 +43,23 @@ function has_command() {
 
 # Install Packages
 if [ $os_name = 'Linux' ]; then
-    if ! python -c 'import OpenSSL' 2> /dev/null; then
-        echo 'You have not installed pyOpenSSL yet.'
-        if [[ $- == *i* ]]; then
-            # interactive shell
-            echo 'Installing pyOpenSSL for your system... Please type in your password if requested'
-            if has_command zypper; then
-                # openSUSE
-                sudo zypper in -y python-pyOpenSSL
-            elif has_command apt-get; then
-                # Debian or Debian-like
-                sudo apt-get install -y python-openssl
-            elif has_command dnf; then
-                # Fedora
-                sudo dnf install -y pyOpenSSL
-            elif has_command yum; then
-                # RedHat
-                sudo yum install -y pyOpenSSL
-            elif has_command pacman; then
-                # ArchLinux
-                sudo pacman -S --noconfirm openssl python2-pyopenssl
-            # Do Someting for OpenWRT
-            fi
-        else
-            # non-interactive shell
-            echo 1>&2 'Please install pyOpenSSL.'
-            #exit 1
+    if ! ${PYTHON} -c 'import OpenSSL' 2> /dev/null; then
+        echo 'Installing pyOpenSSL for your system... Please type in your password if requested'
+        if has_command zypper; then
+            # openSUSE
+            sudo zypper in -y python-pyOpenSSL
+        elif has_command apt-get; then
+            # Debian or Debian-like
+            sudo apt-get install -y python-openssl
+        elif has_command dnf; then
+            # Fedora
+            sudo dnf install -y pyOpenSSL
+        elif has_command yum; then
+            # RedHat
+            sudo yum install -y pyOpenSSL
+        elif has_command pacman; then
+            # ArchLinux
+            sudo pacman -S --noconfirm openssl python2-pyopenssl
         fi
     fi
 fi


### PR DESCRIPTION
这个问题我已经忍了好久了, 主要的修改有2个:

1. Fix ArchLinux下的OpenSSL是否安装的判断, 之前的脚本会默认使用Python 3.
2. 删除了Interactive Shell的判断, 感觉之前的那个判断会影响OpenSSL正常的安装.

我启动XX-Net的方式是`./start`, 每次都不会执行安装脚本. 都提示我`Please install pyOpenSSL`.