### PR TITLE
gae_proxy: cert_util: add subjectAltName extension

### DIFF
--- a/code/default/gae_proxy/local/cert_util.py
+++ b/code/default/gae_proxy/local/cert_util.py
@@ -249,7 +249,7 @@ class CertUtil(object):
             sans = ['*'+commonname] + [s for s in sans if s != '*'+commonname]
         else:
             sans = [commonname] + [s for s in sans if s != commonname]
-        #cert.add_extensions([OpenSSL.crypto.X509Extension(b'subjectAltName', True, ', '.join('DNS: %s' % x for x in sans))])
+        cert.add_extensions([OpenSSL.crypto.X509Extension(b'subjectAltName', True, ', '.join('DNS: %s' % x for x in sans))])
         cert.sign(key, CertUtil.ca_digest)
 
         certfile = os.path.join(CertUtil.ca_certdir, commonname + '.crt')


### PR DESCRIPTION
Both Firefox and Chrome now require "subjectAltName" to exist instead
of just "commonName". Otherwise they report SSL_ERROR_BAD_CERT_DOMAIN
and net::ERR_CERT_COMMON_NAME_INVALID, respectively.

This fixes #5044, fixes #5093, fixes #5106, fixes #5110, and
fixes #5116.