### PR TITLE
Fixed X509Extension has no attribute 'encode' for uncomment SAN code

### DIFF
--- a/code/default/gae_proxy/local/cert_util.py
+++ b/code/default/gae_proxy/local/cert_util.py
@@ -230,7 +230,7 @@ class CertUtil(object):
             subj.commonName = commonname
             subj.organizationName = commonname
             sans = [commonname] + [x for x in sans if x != commonname]
-        #req.add_extensions([OpenSSL.crypto.X509Extension(b'subjectAltName', True, ', '.join('DNS: %s' % x for x in sans)).encode()])
+        req.add_extensions([OpenSSL.crypto.X509Extension(b'subjectAltName', True, ', '.join('DNS: %s' % x for x in sans))])
         req.set_pubkey(pkey)
         req.sign(pkey, CertUtil.ca_digest)
 


### PR DESCRIPTION
Open https://www.google.com in New Version Chrome has been block with NO SAM attribute on certificate.
And the code on Line 252 is not work, Line 233 is work well.