### PR TITLE
Python 3 lambda cannot take explicit tuple param

### DIFF
--- a/code/default/launcher/web_control.py
+++ b/code/default/launcher/web_control.py
@@ -57,7 +57,8 @@ class Http_Handler(simple_http_server.HttpServerHandler):
             module_menu = yaml.load(stream)
             new_module_menus[module] = module_menu
 
-        module_menus = sorted(new_module_menus.iteritems(), key=lambda (k,v): (v['menu_sort_id']))
+        module_menus = sorted(new_module_menus.iteritems(),
+                              key=lambda k_and_v: (k_and_v[1]['menu_sort_id']))
         #for k,v in self.module_menus:
         #    xlog.debug("m:%s id:%d", k, v['menu_sort_id'])
 


### PR DESCRIPTION
A lambda (or a normal function) can not take an explicit tuple as a parameter in Python 3.  Change the lambda to instead take a two tuple (k_and_v) as a single parameter which contains both a key and a value and then use only the value (k_and_v[1]) in the sorted() function.

This is the last issue blocking #6061