### PR TITLE
Emergency Fix: SyntaxError: invalid syntax - 服务器端 Python 语法 BUG 紧急修复！

### DIFF
--- a/code/default/gae_proxy/server/gae/gae.py
+++ b/code/default/gae_proxy/server/gae/gae.py
@@ -121,7 +121,7 @@ def format_response(status, headers, content):
     if content:
         headers.pop('content-length', None)
         headers['Content-Length'] = str(len(content))
-    data = 'HTTP/1.1 %d %s\r\n%s\r\n\r\n%s' % 
+    data = 'HTTP/1.1 %d %s\r\n%s\r\n\r\n%s' % \
             (status,
              httplib.responses.get(status,'Unknown'),
              '\r\n'.join('%s: %s' % (k.title(), v) for k, v in headers.items()),


### PR DESCRIPTION
This will cause Fatal problem in GAE server !!! Result in GAE_Exception 605 'status:500'


Google Log Report:


11:33:20.864
 (/base/data/home/runtimes/python27_experiment/python27_lib/versions/1/google/appengine/runtime/wsgi.py:263)
Traceback (most recent call last):
  File "/base/data/home/runtimes/python27_experiment/python27_lib/versions/1/google/appengine/runtime/wsgi.py", line 240, in Handle
    handler = _config_handle.add_wsgi_middleware(self._LoadHandler())
  File "/base/data/home/runtimes/python27_experiment/python27_lib/versions/1/google/appengine/runtime/wsgi.py", line 299, in _LoadHandler
    handler, path, err = LoadObject(self._handler)
  File "/base/data/home/runtimes/python27_experiment/python27_lib/versions/1/google/appengine/runtime/wsgi.py", line 85, in LoadObject
    obj = __import__(path[0])
  File "/base/data/home/apps/s~radar1-179201/1.403929351434169704/gae.py", line 124
    data = 'HTTP/1.1 %d %s\r\n%s\r\n\r\n%s' %
                                             ^
SyntaxError: invalid syntax