### PR TITLE
Add update notify

### DIFF
--- a/code/default/gae_proxy/web_ui/status.html
+++ b/code/default/gae_proxy/web_ui/status.html
@@ -7,8 +7,6 @@
 
 <div id="noob-info" class=""></div>
 
-<div id="notify_area" class="notify_area"> </div>
-
 <div id="details" hidden>
     <h4>{{ _( "Status" ) }}</h4>
     <table id="status" class="table table-bordered table-striped">
@@ -574,64 +572,5 @@
             }
         });
     };
-</script>
-
-<script type="text/javascript">
-    //pop up notify on top of status web page.
-    function popup_notify(text,linkText,linkHref,open_in_newtab,bcolor)
-    {
-        var notify_area=document.getElementById("notify_area");
-        
-        //create new div for notify
-        var newdiv=notify_area.appendChild(document.createElement("div"));
-        newdiv.className="popnotify";
-        if(bcolor != "")
-        {
-            newdiv.style.backgroundColor=bcolor;
-        }
-        
-        //in new div create span as notify text
-        var notify_text_span=newdiv.appendChild(document.createElement("span"));
-        //write the notify text in
-        notify_text_span.appendChild(document.createTextNode(text));
-        
-        //in new div create span as link
-        var notify_link_span=newdiv.appendChild(document.createElement("span"));
-        //in link span create link
-        var notify_link=notify_link_span.appendChild(document.createElement("a"));
-        if(linkHref)
-        {
-            //write link address in
-            notify_link.href=linkHref;
-        }
-        else
-            notify_link.href="#"; //go nowhere
-        if(open_in_newtab)
-        {
-            notify_link.target="_blank";
-        }
-        //write link text in
-        notify_link.appendChild(document.createTextNode(linkText));
-        
-        //create close notify button
-        var notify_close_btn=newdiv.appendChild(document.createElement("span"));
-        //notify_close_btn.className="";
-        notify_close_btn.appendChild(document.createTextNode("X"));
-        notify_close_btn.style="float:right; cursor: pointer;";
-        notify_close_btn.onclick=function()
-        {
-            //close this popup
-            notify_area.removeChild(this.parentNode);
-        }
-        //return the link object , can be used as button
-        return notify_link_span;
-    }
-    //Examples .  uncomment to see .
-    /*
-    var aaa=popup_notify("This is notify example. ","click text");
-    aaa.onclick=function() { alert('hello'); } 
-    popup_notify("This is notify example 2 . ", "","","", "yellow");
-    popup_notify("This is notify example 3 . ","Link text","whereDoWeGo",1,"#dddddd");
-    */
 </script>
 

--- a/code/default/gae_proxy/web_ui/status.html
+++ b/code/default/gae_proxy/web_ui/status.html
@@ -250,7 +250,7 @@
     }
 </script>
 <script type="text/javascript">
-    $(document).ready(function(){
+    documentReadyToRun.push(function(){
         var timer = $.timer(function() {
             if ( $("#details").is(":visible")){
                 updateDetailStatus();

--- a/code/default/launcher/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/code/default/launcher/lang/zh_CN/LC_MESSAGES/messages.po
@@ -70,8 +70,14 @@ msgstr "自动升级到"
 msgid "Do not upgrade"
 msgstr "不升级"
 
+msgid "Notice stable version"
+msgstr "通知稳定版"
+
 msgid "Stable version"
 msgstr "稳定版"
+
+msgid "Notice test version"
+msgstr "通知测试版"
 
 msgid "Test version"
 msgstr "测试版"
@@ -85,8 +91,17 @@ msgstr "当前版本"
 msgid "Version of the test one"
 msgstr "测试版版本"
 
+msgid "is valid."
+msgstr "已经可用。"
+
 msgid "Update now"
 msgstr "立即更新"
+
+msgid "Remind me next time"
+msgstr "下次再提醒我"
+
+msgid "Do not remind me this version"
+msgstr "不要再提醒我更新这个版本"
 
 msgid "Version of the stable one"
 msgstr "稳定版版本"

--- a/code/default/launcher/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/code/default/launcher/lang/zh_CN/LC_MESSAGES/messages.po
@@ -100,7 +100,7 @@ msgstr "立即更新"
 msgid "Remind me next time"
 msgstr "下次再提醒我"
 
-msgid "Do not remind me this version"
+msgid "Do not remind me of this version"
 msgstr "不要再提醒我更新这个版本"
 
 msgid "Version of the stable one"

--- a/code/default/launcher/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/code/default/launcher/lang/zh_CN/LC_MESSAGES/messages.po
@@ -109,6 +109,12 @@ msgstr "稳定版版本"
 msgid "All versions download page"
 msgstr "所有版本下载页面"
 
+msgid "Downloading ..."
+msgstr "下载中……"
+
+msgid "Download completed"
+msgstr "下载完成"
+
 msgid "Module management"
 msgstr "模块管理"
 

--- a/code/default/launcher/update.py
+++ b/code/default/launcher/update.py
@@ -234,25 +234,37 @@ def general_gtk_callback(widget=None, data=None):
 
 def check_update():
     try:
-        update_rule = config.get(["update", "check_update"], "stable")
-        if update_rule == "dont-check":
+        if update_from_github.update_info == "dont-check":
             return
 
         check_push_update()
 
-        if update_rule != "stable" and update_rule != "test":
+        update_rule = config.get(["update", "check_update"], "notice-stable")
+        if update_rule not in ("stable", "notice-stable", "test", "notice-test"):
             return
 
         versions = update_from_github.get_github_versions()
         current_version = update_from_github.current_version()
-        if update_rule == "test":
-            if LooseVersion(current_version) < LooseVersion(versions[0][1]):
-                xlog.info("update to test version %s", versions[0][1])
-                update_from_github.update_version(versions[0][1])
-        elif update_rule == "stable":
-            if LooseVersion(current_version) < LooseVersion(versions[1][1]):
-                xlog.info("update to stable version %s", versions[1][1])
-                update_from_github.update_version(versions[1][1])
+        skip_version = config.get(["update", "skip_version"])
+        test_version, stable_version = versions[0][1], versions[1][1]
+        if test_version != skip_version:
+            if update_rule == "notice-test":
+                if LooseVersion(current_version) < LooseVersion(test_version):
+                    xlog.info("checked new test version %s", test_version)
+                    update_from_github.update_info = '{"type":"test", "version":"%s"}' % test_version
+            elif update_rule == "test":
+                if LooseVersion(current_version) < LooseVersion(test_version):
+                    xlog.info("update to test version %s", test_version)
+                    update_from_github.update_version(test_version)
+        if stable_version != skip_version:
+            if update_rule == "notice-stable":
+                if LooseVersion(current_version) < LooseVersion(stable_version):
+                    xlog.info("checked new stable version %s", stable_version)
+                    update_from_github.update_info = '{"type":"stable", "version":"%s"}' % stable_version
+            elif update_rule == "stable":
+                if LooseVersion(current_version) < LooseVersion(stable_version):
+                    xlog.info("update to stable version %s", stable_version)
+                    update_from_github.update_version(stable_version)
     except IOError as e:
         xlog.warn("check update fail:%r", e)
     except Exception as e:

--- a/code/default/launcher/update.py
+++ b/code/default/launcher/update.py
@@ -269,6 +269,9 @@ def check_update():
         xlog.warn("check update fail:%r", e)
     except Exception as e:
         xlog.exception("check_update fail:%r", e)
+    finally:
+        if update_from_github.update_info == "init":
+            update_from_github.update_info = ""
 
 def check_push_update():
     global update_content, update_dict

--- a/code/default/launcher/update.py
+++ b/code/default/launcher/update.py
@@ -245,9 +245,8 @@ def check_update():
 
         versions = update_from_github.get_github_versions()
         current_version = update_from_github.current_version()
-        skip_version = config.get(["update", "skip_version"])
         test_version, stable_version = versions[0][1], versions[1][1]
-        if test_version != skip_version:
+        if test_version != config.get(["update", "skip_test_version"]):
             if update_rule == "notice-test":
                 if LooseVersion(current_version) < LooseVersion(test_version):
                     xlog.info("checked new test version %s", test_version)
@@ -256,7 +255,7 @@ def check_update():
                 if LooseVersion(current_version) < LooseVersion(test_version):
                     xlog.info("update to test version %s", test_version)
                     update_from_github.update_version(test_version)
-        if stable_version != skip_version:
+        if stable_version != config.get(["update", "skip_stable_version"]):
             if update_rule == "notice-stable":
                 if LooseVersion(current_version) < LooseVersion(stable_version):
                     xlog.info("checked new stable version %s", stable_version)

--- a/code/default/launcher/update_from_github.py
+++ b/code/default/launcher/update_from_github.py
@@ -69,7 +69,6 @@ def download_file(url, filename):
         try:
             xlog.info("download %s to %s, retry:%d", url, filename, i)
             opener = get_opener(i)
-            #opener.addheaders += [('Range', 'bytes=0-')]
             req = opener.open(url, timeout=30)
             progress[url]["size"] = int(req.headers.get('content-length') or 0)
 

--- a/code/default/launcher/update_from_github.py
+++ b/code/default/launcher/update_from_github.py
@@ -33,6 +33,17 @@ if not os.path.isdir(download_path):
 
 progress = {} # link => {"size", 'downloaded', status:downloading|canceled|finished:failed}
 progress["update_status"] = "Idle"
+update_info = "init"
+
+def init_update_info(check_update):
+    global update_info
+    if check_update == "dont-check":
+        update_info = "dont-check"
+    elif config.get(["update", "check_update"]) == update_info == "dont-check":
+        update_info = "init"
+
+init_update_info(config.get(["update", "check_update"]))
+#update_info = '{"type":"stable", "version":"3.3.3"}'
 
 def get_opener(retry=0):
     if retry == 0:
@@ -259,7 +270,9 @@ def restart_xxnet(version):
 
 
 def update_version(version):
-    global update_progress
+    global update_progress, update_info
+    _update_info = update_info
+    update_info = ""
     try:
         download_overwrite_new_version(version)
 
@@ -270,6 +283,7 @@ def update_version(version):
         restart_xxnet(version)
     except Exception as e:
         xlog.warn("update version %s fail:%r", version, e)
+        update_info = _update_info
 
 
 def start_update_version(version):

--- a/code/default/launcher/update_from_github.py
+++ b/code/default/launcher/update_from_github.py
@@ -41,9 +41,10 @@ def init_update_info(check_update):
         update_info = "dont-check"
     elif config.get(["update", "check_update"]) == update_info == "dont-check":
         update_info = "init"
+    elif check_update != "init":
+        update_info = ""
 
 init_update_info(config.get(["update", "check_update"]))
-#update_info = '{"type":"stable", "version":"3.3.3"}'
 
 def get_opener(retry=0):
     if retry == 0:
@@ -68,6 +69,7 @@ def download_file(url, filename):
         try:
             xlog.info("download %s to %s, retry:%d", url, filename, i)
             opener = get_opener(i)
+            #opener.addheaders += [('Range', 'bytes=0-')]
             req = opener.open(url, timeout=30)
             progress[url]["size"] = int(req.headers.get('content-length') or 0)
 

--- a/code/default/launcher/web_control.py
+++ b/code/default/launcher/web_control.py
@@ -246,11 +246,15 @@ class Http_Handler(simple_http_server.HttpServerHandler):
         elif reqs['cmd'] == ['set_config']:
             if 'skip_version' in reqs:
                 skip_version = reqs['skip_version'][0]
-                config.set(["update", "skip_version"], skip_version)
-                config.save()
-                if skip_version in update_from_github.update_info:
-                    update_from_github.update_info = ''
-                data = '{"res":"success"}'
+                skip_version_type = reqs['skip_version_type'][0]
+                if skip_version_type not in ["stable", "test"]:
+                    data = '{"res":"fail"}'
+                else:
+                    config.set(["update", "skip_%s_version" % skip_version_type], skip_version)
+                    config.save()
+                    if skip_version in update_from_github.update_info:
+                        update_from_github.update_info = ''
+                    data = '{"res":"success"}'
             elif 'check_update' in reqs:
                 check_update = reqs['check_update'][0]
                 if check_update not in ["dont-check", "stable", "notice-stable", "test", "notice-test"]:

--- a/code/default/launcher/web_ui/config.html
+++ b/code/default/launcher/web_ui/config.html
@@ -54,7 +54,9 @@
             <div class="span6">
                 <select id="check-update">
                     <option value="dont-check">{{ _( "Do not upgrade" ) }}</option>
+                    <option value="notice-stable">{{ _( "Notice stable version" ) }}</option>
                     <option value="stable">{{ _( "Stable version" ) }}</option>
+                    <option value="notice-test">{{ _( "Notice test version" ) }}</option>
                     <option value="test">{{ _( "Test version" ) }}</option>
                 </select>
             </div>
@@ -236,6 +238,11 @@
         var key   = 'check_update',
             value = $(this).val();
 
+        if ( value == 'dont-check' ) {
+            stopUpdateCheck()
+        } else {
+            startUpdateCheck()
+        }
         return setConfig(key, value);
     });
 

--- a/code/default/launcher/web_ui/config.html
+++ b/code/default/launcher/web_ui/config.html
@@ -427,122 +427,18 @@
 <script type="text/javascript">
 
     $('.update-button').click(function(){
-        var pageRequests = {};
-        pageRequests['cmd'] = 'update_version';
-
         var id = $(this).attr('id');
         if(id == 'update-test-version'){
-            pageRequests['version'] = $('#test-version-no').html();
+            versionToUpdate = $('#test-version-no').html();
             //window.updating_button = $('#update-test-version');
         }else if(id == 'update-stable-version'){
-            pageRequests['version'] = $('#stable-version-no').html();
+            versionToUpdate = $('#stable-version-no').html();
             //window.updating_button = $('#update-stable-version');
         }
 
         window.loading = Ladda.create(this);
         window.loading.start();
 
-        $.ajax({
-            type: 'GET',
-            url: '/update',
-            data: pageRequests,
-            dataType: 'JSON',
-            success: function(result) {
-                if ( result['res'] == 'success' ) {
-                    tip( '{{ _( "Updating in progress ..." ) }}', "info");
-                    window.timer.play()
-                } else {
-                    tip( result['reason'], "warning");
-                }
-            },
-            error: function() {
-                displayErrorMessage();
-            }
-        });
-    });
-
-    function updateProgress(){
-        $.getJSON('update?cmd=get_progress', function (rst) {
-            Object.keys(rst).forEach(function (v) {
-                if ( v == "update_status"){
-                    var stat = rst[v];
-
-                    if ( stat === "Idle"){
-                        window.timer.stop();
-                        return;
-                    }
-
-                    if ( $('#upgrade-pull-icon').hasClass('icon-chevron-right') ){
-                        var current_version = $('#current-version-no').html();
-                        if ( current_version == ""){
-                            $('#current-version-no').html(" ");
-                            // avoid check next time.
-
-                            check_new_version();
-                        }
-
-                        $('.version-line').slideDown('fast');
-
-                        $('#upgrade-pull-icon').removeClass('icon-chevron-right');
-                        $('#upgrade-pull-icon').addClass('icon-chevron-down');
-                        $('#update-options').slideDown();
-                    }
-
-                    if( stat == "Finished"){
-                        tip( stat, 'info');
-                        window.loading.stop();
-                        window.timer.stop();
-                        return;
-                    }else if ( stat.indexOf('Fail') > -1){
-                        tip( stat, 'warning');
-                        window.timer.stop();
-                    }else{
-                        tip( stat, 'info');
-                    }
-                }else if (v.indexOf('XX-Net/zip') > -1) {
-                    if (!window.updating_button){
-                        var p = v.indexOf('XX-Net/zip') + 11;
-                        var version = v.substring(p, v.length);
-                        var button;
-                        if ( version == $('#test-version-no').html() ){
-                            button = $('#update-test-version');
-                        }else if ( version == $('#stable-version-no').html() ){
-                            button = $('#update-stable-version');
-                        }else{
-                            return;
-                        }
-                        window.updating_button = button;
-                    }
-
-                    if (!window.loading){
-                        window.loading = Ladda.create(window.updating_button[0]);
-                        window.loading.start();
-                    }
-                    var data = rst[v];
-                    if ( data.status === 'downloading'){
-                        var progress =  (+data.downloaded / +data.size) * 100 ;
-
-                        window.loading.setProgress(progress);
-                        window.updating_button.html('{{ _( "Downloading ..." ) }}' + parseInt(progress) + '%');
-                    }else if (data.status === "finished"){
-                        window.updating_button.html( '{{ _( "Download completed" ) }}');
-                        window.updating_button.prop('disabled', true);
-                    }
-                }
-            });
-        });
-    }
-
-    $(document).ready(function(){
-        window.timer = $.timer(function() {
-            updateProgress();
-        });
-
-        window.timer.set({
-            time: 1000,
-            autostart: true
-        });
-
-        updateProgress();
+        updateVersion();
     });
 </script>

--- a/code/default/launcher/web_ui/config.html
+++ b/code/default/launcher/web_ui/config.html
@@ -309,11 +309,6 @@
     }
 </script>
 <script type="text/javascript">
-    function displayErrorMessage() {
-        tip('{{ _( "Unkown error occured. Please refresh the page and try again" ) }}', 'error');
-    }
-</script>
-<script type="text/javascript">
     function restartingService(serviceNameSlug) {
         var serviceName     = '',
             restatingTime   = 5,

--- a/code/default/launcher/web_ui/css/style.css
+++ b/code/default/launcher/web_ui/css/style.css
@@ -265,15 +265,33 @@ div#content div#options div.row-fluid div.span4, .bold {
     border-color: #bce8f1;
 }
 
-.popnotify{
-    padding: 10px;
-    margin: 40px 0;
-    color: #b94a48;
+#update-notify, .popnotify {
+    padding: 6px;
+    margin: 10px 0;
     background-color: #dff0d8;
     border:1px solid;
-    border-color: #eed3d7;
+    border-color: #cfe0c8;
     border-radius: 4px;
     transition: color .3s,background .3s,border .3s;
+    
+}
+#update-message{
+    font-size: 120%;
+    color: #507050;
+}
+.update-notify-action {
+    float: right;
+    color: #0072E3;
+    cursor: pointer;
+    margin: 0 6px;
+}
+
+#update-notify-close {
+    float: right;
+    cursor: pointer;
+    margin-left: 7px;
+    color: #b94a48;
+    
 }
 
 #details, #update-options, #modules-manager{

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -66,14 +66,14 @@
                     </div> <!-- .sidebar-nav -->
                 </div> <!-- #sidebar -->
                 <div class="span9">
-                    <div id="update-notify">
+                    <div id="update-notify" class="alert fade in hide">
                         <span id="update-notify-close">×</span>
                         <span id="update-skip" class="update-notify-action">{{ _( "Do not remind me of this version" ) }}</span>
                         <span id="update-next" class="update-notify-action">{{ _( "Remind me next time" ) }}</span>
                         <span id="update-now" class="update-notify-action">{{ _( "Update now" ) }}</span>
                         <span id="update-message"></span>
                     </div> <!-- #update-notify -->
-                    <div id="update-progress-bar">
+                    <div id="update-progress-bar" class="alert fade in hide">
                         <button class="btn btn-primary ladda-button"></button>
                     </div><!-- #update-progress-bar -->
                     <h2 id="title"></h2>
@@ -414,8 +414,6 @@
         $('#update-next').click(clearUpdateInfo);
         $('#update-skip').click(skipUpdateVersion);
         $('#update-notify-close').click(clearUpdateInfo);
-        $('#update-notify').addClass('hide');
-        $('#update-progress-bar').addClass('hide');
         // site.js fix
         $('#tip-close').click(tipClose);
     </script>

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -26,7 +26,6 @@
 </head>
 <script type="text/javascript">
     var documentReadyToRun = new Array();
-    var check_new_version;
 </script>
 <body>
     <div id="header" class="navbar navbar-inverse navbar-fixed-top">
@@ -335,7 +334,7 @@
 
                         if ( $('#upgrade-pull-icon').hasClass('icon-chevron-right') ){
                             var current_version = $('#current-version-no').html();
-                            if ( current_version == "" && check_new_version){
+                            if ( current_version == "" && $('.active a').attr('href') == '/?module=launcher&menu=config'){
                                 $('#current-version-no').html(" ");
                                 // avoid check next time.
 
@@ -369,7 +368,7 @@
                                 button = $('#update-test-version');
                             }else if ( version == $('#stable-version-no').html() ){
                                 button = $('#update-stable-version');
-                            }else if ( check_new_version ) {
+                            }else if ( $('.active a').attr('href') == '/?module=launcher&menu=config' ) {
                                 return;
                             }else{
                                 button = $('#update-progress-bar button');

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -24,6 +24,9 @@
         <script type="text/javascript" src="/js/jquery.xdomainrequest.min.js"></script>
     <![endif]-->
 </head>
+<script type="text/javascript">
+    var documentReadyToRun = new Array();
+</script>
 <body>
     <div id="header" class="navbar navbar-inverse navbar-fixed-top">
         <div class="navbar-inner">
@@ -70,6 +73,9 @@
                         <span id="update-now" class="update-notify-action">{{ _( "Update now" ) }}</span>
                         <span id="update-message"></span>
                     </div> <!-- #update-notify -->
+                    <div id="update-progress-bar">
+                        <button class="btn btn-primary ladda-button"></button>
+                    </div><!-- #update-progress-bar -->
                     <h2 id="title"></h2>
                     <div id="tip" class="alert fade in hide">
                         <button id="tip-close" type="button" class="close">×</button>
@@ -141,17 +147,22 @@
     <script type="text/javascript">
         var checkUpdateTimeout = 600000;
         var checkUpdateTimer;
-        var isShown;
-        var version;
-        var poptip;
+        var versionToUpdate;
 
         function displayErrorMessage() {
             tip('{{ _( "Unkown error occured. Please refresh the page and try again" ) }}', 'error');
         }
 
         function clearNotify() {
-            $('#update-notify').css('display', 'none');
-            isShown = null;
+            if ( !$('#update-notify').hasClass('hide') ) {
+                $('#update-notify').addClass('hide');
+            }
+        }
+
+        function clearProgressBar() {
+            if ( !$('#update-progress-bar').hasClass('hide') ) {
+                $('#update-progress-bar').addClass('hide');
+            }
         }
 
         function startUpdateCheck() {
@@ -233,7 +244,7 @@
             checkUpdateTimer.stop();
             var pageRequests = {};
             pageRequests['cmd'] = 'set_config';
-            pageRequests['skip_version'] = version;
+            pageRequests['skip_version'] = versionToUpdate;
 
             $.ajax({
                 type: 'GET',
@@ -255,8 +266,8 @@
             clearNotify();
             var pageRequests = {};
             pageRequests['cmd'] = 'update_version';
-            pageRequests['version'] = version;
-            version = null;
+            pageRequests['version'] = versionToUpdate;
+            versionToUpdate = null;
 
             $.ajax({
                 type: 'GET',
@@ -266,6 +277,8 @@
                 success: function(result) {
                     if ( result['res'] == 'success' ) {
                         tip( '{{ _( "Updating in progress ..." ) }}', "info");
+                        $('#update-progress-bar button').html(pageRequests['version']);
+                        window.timer.play();
                     } else {
                         tip( result['reason'], "warning");
                     }
@@ -277,7 +290,8 @@
         }
 
         function getUpdateInfo() {
-            if (isShown) {
+            if ( !$('#update-notify').hasClass('hide') ||
+                 !$('#update-progress-bar').hasClass('hide')) {
                 return;
             }
 
@@ -299,31 +313,120 @@
                         stopUpdateCheck();
                         break;
                     default:
-                        version = result['version'];
-                        if ( versionType && version ) {
+                        versionToUpdate = result['version'];
+                        if ( versionType && versionToUpdate ) {
                             switch ( versionType ) {
                             case 'stable':
-                                popText = '{{ _( "Stable version" ) }} ' + version + ' {{ _( "is valid." ) }}';
+                                var popText = '{{ _( "Stable version" ) }} ' + versionToUpdate + ' {{ _( "is valid." ) }}';
                                 break;
                             case 'test':
-                                popText = '{{ _( "Test version" ) }} ' + version + ' {{ _( "is valid." ) }}';
+                                var popText = '{{ _( "Test version" ) }} ' + versionToUpdate + ' {{ _( "is valid." ) }}';
                             }
                             $('#update-message').text(popText);
-                            $('#update-notify').css('display', '');
-                            isShown = true;
+                            if ( $('#update-notify').hasClass('hide') ) {
+                                $('#update-notify').removeClass('hide');
+                            }
                         }
                     }
                 }
             });
         }
 
+        function updateProgress(){
+            $.getJSON('update?cmd=get_progress', function (rst) {
+                Object.keys(rst).forEach(function (v) {
+                    if ( v == "update_status"){
+                        var stat = rst[v];
+
+                        if ( stat === "Idle"){
+                            window.timer.stop();
+                            return;
+                        }
+
+                        if ( $('#upgrade-pull-icon').hasClass('icon-chevron-right') ){
+                            var current_version = $('#current-version-no').html();
+                            if ( current_version == ""){
+                                $('#current-version-no').html(" ");
+                                // avoid check next time.
+
+                                check_new_version();
+                            }
+
+                            $('.version-line').slideDown('fast');
+
+                            $('#upgrade-pull-icon').removeClass('icon-chevron-right');
+                            $('#upgrade-pull-icon').addClass('icon-chevron-down');
+                            $('#update-options').slideDown();
+                        }
+
+                        if( stat == "Finished"){
+                            tip( stat, 'info');
+                            window.loading.stop();
+                            window.timer.stop();
+                            return;
+                        }else if ( stat.indexOf('Fail') > -1){
+                            tip( stat, 'warning');
+                            window.timer.stop();
+                        }else{
+                            tip( stat, 'info');
+                        }
+                    }else if (v.indexOf('XX-Net/zip') > -1) {
+                        if (!window.updating_button){
+                            var p = v.indexOf('XX-Net/zip') + 11;
+                            var version = v.substring(p, v.length);
+                            var button;
+                            if ( version == $('#test-version-no').html() ){
+                                button = $('#update-test-version');
+                            }else if ( version == $('#stable-version-no').html() ){
+                                button = $('#update-stable-version');
+                            }else if ( version == $('#update-progress-bar button').html() ){
+                                button = $('#update-progress-bar button');
+                                if ( $('#update-progress-bar').hasClass('hide') ) {
+                                    $('#update-progress-bar').removeClass('hide');
+                                }
+                            }else{
+                                return;
+                            }
+                            window.updating_button = button;
+                        }
+
+                        if (!window.loading){
+                            window.loading = Ladda.create(window.updating_button[0]);
+                            window.loading.start();
+                        }
+                        var data = rst[v];
+                        if ( data.status === 'downloading'){
+                            var progress =  (+data.downloaded / +data.size) * 100 ;
+
+                            window.loading.setProgress(progress);
+                            window.updating_button.html('{{ _( "Downloading ..." ) }}' + parseInt(progress) + '&#37;');
+                        }else if (data.status === "finished"){
+                            window.updating_button.html( '{{ _( "Download completed" ) }}');
+                            window.updating_button.prop('disabled', true);
+                            window.setTimeout(clearProgressBar, 5000);
+                        }
+                    }
+                });
+            });
+        }
+
+        $(document).ready(function(){
+            var rfn;
+            for ( rfn in documentReadyToRun ) {
+                documentReadyToRun[rfn]();
+            }
+            window.timer = $.timer(updateProgress, 1000, true);
+            updateProgress();
+            checkUpdateTimer = $.timer(getUpdateInfo, checkUpdateTimeout, true);
+            getUpdateInfo();
+        });
+
         $('#update-now').click(updateVersion);
         $('#update-next').click(clearUpdateInfo);
         $('#update-skip').click(skipUpdateVersion);
         $('#update-notify-close').click(clearUpdateInfo);
         clearNotify();
-        getUpdateInfo();
-        checkUpdateTimer = $.timer(getUpdateInfo, checkUpdateTimeout, true);
+        clearProgressBar();
     </script>
     <script type="text/javascript">
         //pop up notify on top of status web page.

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -26,6 +26,7 @@
 </head>
 <script type="text/javascript">
     var documentReadyToRun = new Array();
+    var check_new_version;
 </script>
 <body>
     <div id="header" class="navbar navbar-inverse navbar-fixed-top">
@@ -73,7 +74,7 @@
                         <span id="update-now" class="update-notify-action">{{ _( "Update now" ) }}</span>
                         <span id="update-message"></span>
                     </div> <!-- #update-notify -->
-                    <div id="update-progress-bar" class="alert fade in hide">
+                    <div id="update-progress-bar" class="fade in hide">
                         <button class="btn btn-primary ladda-button"></button>
                     </div><!-- #update-progress-bar -->
                     <h2 id="title"></h2>
@@ -269,7 +270,6 @@
                 success: function(result) {
                     if ( result['res'] == 'success' ) {
                         tip( '{{ _( "Updating in progress ..." ) }}', "info");
-                        $('#update-progress-bar button').html(pageRequests['version']);
                         window.timer.play();
                     } else {
                         tip( result['reason'], "warning");
@@ -335,7 +335,7 @@
 
                         if ( $('#upgrade-pull-icon').hasClass('icon-chevron-right') ){
                             var current_version = $('#current-version-no').html();
-                            if ( current_version == ""){
+                            if ( current_version == "" && check_new_version){
                                 $('#current-version-no').html(" ");
                                 // avoid check next time.
 
@@ -369,14 +369,15 @@
                                 button = $('#update-test-version');
                             }else if ( version == $('#stable-version-no').html() ){
                                 button = $('#update-stable-version');
-                            }else if ( version == $('#update-progress-bar button').html() ){
+                            }else if ( check_new_version ) {
+                                return;
+                            }else{
                                 button = $('#update-progress-bar button');
                                 $('#update-progress-bar').removeClass('hide');
-                            }else{
-                                return;
                             }
                             window.updating_button = button;
                         }
+                        $('#update-notify').addClass('hide');
 
                         if (!window.loading){
                             window.loading = Ladda.create(window.updating_button[0]);
@@ -391,7 +392,9 @@
                         }else if (data.status === "finished"){
                             window.updating_button.html( '{{ _( "Download completed" ) }}');
                             window.updating_button.prop('disabled', true);
+                            window.updating_button = null;
                             window.setTimeout(clearProgressBar, 5000);
+                            window.loading.stop();
                             window.timer.stop();
                         }
                     }
@@ -407,7 +410,7 @@
             window.timer = $.timer(updateProgress, 1000, true);
             updateProgress();
             checkUpdateTimer = $.timer(getUpdateInfo, checkUpdateTimeout, true);
-            getUpdateInfo();
+            window.setTimeout(getUpdateInfo, 1000);
         });
 
         $('#update-now').click(updateVersion);

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -153,20 +153,12 @@
             tip('{{ _( "Unkown error occured. Please refresh the page and try again" ) }}', 'error');
         }
 
-        function clearNotify() {
-            if ( !$('#update-notify').hasClass('hide') ) {
-                $('#update-notify').addClass('hide');
-            }
-        }
-
         function clearProgressBar() {
-            if ( !$('#update-progress-bar').hasClass('hide') ) {
-                $('#update-progress-bar').addClass('hide');
-            }
+            $('#update-progress-bar').addClass('hide');
         }
 
         function startUpdateCheck() {
-            clearNotify();
+            $('#update-notify').addClass('hide');
             var pageRequests = {};
             pageRequests['cmd'] = 'start_check';
             check_update = $('#check-update').val();
@@ -195,7 +187,7 @@
         }
 
         function stopUpdateCheck() {
-            clearNotify();
+            $('#update-notify').addClass('hide');
             checkUpdateTimer.stop();
             var pageRequests = {};
             pageRequests['cmd'] = 'set_info';
@@ -218,7 +210,7 @@
         }
 
         function clearUpdateInfo() {
-            clearNotify();
+            $('#update-notify').addClass('hide');
             var pageRequests = {};
             pageRequests['cmd'] = 'set_info';
             pageRequests['info'] = '';
@@ -240,7 +232,7 @@
         }
 
         function skipUpdateVersion() {
-            clearNotify();
+            $('#update-notify').addClass('hide');
             checkUpdateTimer.stop();
             var pageRequests = {};
             pageRequests['cmd'] = 'set_config';
@@ -263,7 +255,7 @@
         }
 
         function updateVersion() {
-            clearNotify();
+            $('#update-notify').addClass('hide');
             var pageRequests = {};
             pageRequests['cmd'] = 'update_version';
             pageRequests['version'] = versionToUpdate;
@@ -323,9 +315,7 @@
                                 var popText = '{{ _( "Test version" ) }} ' + versionToUpdate + ' {{ _( "is valid." ) }}';
                             }
                             $('#update-message').text(popText);
-                            if ( $('#update-notify').hasClass('hide') ) {
-                                $('#update-notify').removeClass('hide');
-                            }
+                            $('#update-notify').removeClass('hide');
                         }
                     }
                 }
@@ -381,9 +371,7 @@
                                 button = $('#update-stable-version');
                             }else if ( version == $('#update-progress-bar button').html() ){
                                 button = $('#update-progress-bar button');
-                                if ( $('#update-progress-bar').hasClass('hide') ) {
-                                    $('#update-progress-bar').removeClass('hide');
-                                }
+                                $('#update-progress-bar').removeClass('hide');
                             }else{
                                 return;
                             }
@@ -426,8 +414,10 @@
         $('#update-next').click(clearUpdateInfo);
         $('#update-skip').click(skipUpdateVersion);
         $('#update-notify-close').click(clearUpdateInfo);
-        clearNotify();
-        clearProgressBar();
+        $('#update-notify').addClass('hide');
+        $('#update-progress-bar').addClass('hide');
+        // site.js fix
+        $('#tip-close').click(tipClose);
     </script>
     <script type="text/javascript">
         //pop up notify on top of status web page.

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -155,6 +155,7 @@
         }
 
         function startUpdateCheck() {
+            clearNotify();
             var pageRequests = {};
             pageRequests['cmd'] = 'start_check';
             check_update = $('#check-update').val();

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -404,6 +404,7 @@
                             window.updating_button.html( '{{ _( "Download completed" ) }}');
                             window.updating_button.prop('disabled', true);
                             window.setTimeout(clearProgressBar, 5000);
+                            window.timer.stop();
                         }
                     }
                 });

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -63,6 +63,13 @@
                     </div> <!-- .sidebar-nav -->
                 </div> <!-- #sidebar -->
                 <div class="span9">
+                    <div id="update-notify">
+                        <span id="update-notify-close">×</span>
+                        <span id="update-skip" class="update-notify-action">{{ _( "Do not remind me this version" ) }}</span>
+                        <span id="update-next" class="update-notify-action">{{ _( "Remind me next time" ) }}</span>
+                        <span id="update-now" class="update-notify-action">{{ _( "Update now" ) }}</span>
+                        <span id="update-message"></span>
+                    </div> <!-- #update-notify -->
                     <h2 id="title"></h2>
                     <div id="tip" class="alert fade in hide">
                         <button id="tip-close" type="button" class="close">×</button>
@@ -130,6 +137,247 @@
                 }
             }
         });
+    </script>
+    <script type="text/javascript">
+        var checkUpdateTimeout = 600000;
+        var checkUpdateTimer;
+        var isShown;
+        var version;
+        var poptip;
+
+        function displayErrorMessage() {
+            tip('{{ _( "Unkown error occured. Please refresh the page and try again" ) }}', 'error');
+        }
+
+        function clearNotify() {
+            $('#update-notify').css('display', 'none');
+            isShown = null;
+        }
+
+        function startUpdateCheck() {
+            var pageRequests = {};
+            pageRequests['cmd'] = 'start_check';
+            pageRequests['check_update'] = $('#check-update').val();
+
+            $.ajax({
+                type: 'GET',
+                url: '/update',
+                data: pageRequests,
+                dataType: 'JSON',
+                success: function(result) {
+                    if ( result['res'] == 'success' ) {
+                        getUpdateInfo();
+                        checkUpdateTimer.play();
+                    } else {
+                        tip( result['reason'], "warning");
+                    }
+                },
+                error: function() {
+                    displayErrorMessage();
+                }
+            });
+        }
+
+        function stopUpdateCheck() {
+            checkUpdateTimer.stop();
+            var pageRequests = {};
+            pageRequests['cmd'] = 'set_info';
+            pageRequests['info'] = 'dont-check';
+
+            $.ajax({
+                type: 'GET',
+                url: '/update',
+                data: pageRequests,
+                dataType: 'JSON',
+                success: function(result) {
+                    if ( result['res'] != 'success' ) {
+                        tip( result['reason'], "warning");
+                    }
+                },
+                error: function() {
+                    displayErrorMessage();
+                }
+            });
+        }
+
+        function clearUpdateInfo() {
+            clearNotify();
+            var pageRequests = {};
+            pageRequests['cmd'] = 'set_info';
+            pageRequests['info'] = '';
+
+            $.ajax({
+                type: 'GET',
+                url: '/update',
+                data: pageRequests,
+                dataType: 'JSON',
+                success: function(result) {
+                    if ( result['res'] != 'success' ) {
+                        tip( result['reason'], "warning");
+                    }
+                },
+                error: function() {
+                    displayErrorMessage();
+                }
+            });
+        }
+
+        function skipUpdateVersion() {
+            clearNotify();
+            checkUpdateTimer.stop();
+            var pageRequests = {};
+            pageRequests['cmd'] = 'set_config';
+            pageRequests['skip_version'] = version;
+
+            $.ajax({
+                type: 'GET',
+                url: '/config',
+                data: pageRequests,
+                dataType: 'JSON',
+                success: function(result) {
+                    if ( result['res'] != 'success' ) {
+                        tip( result['reason'], "warning");
+                    }
+                },
+                error: function() {
+                    displayErrorMessage();
+                }
+            });
+        }
+
+        function updateVersion() {
+            clearNotify();
+            var pageRequests = {};
+            pageRequests['cmd'] = 'update_version';
+            pageRequests['version'] = version;
+            version = null;
+
+            $.ajax({
+                type: 'GET',
+                url: '/update',
+                data: pageRequests,
+                dataType: 'JSON',
+                success: function(result) {
+                    if ( result['res'] == 'success' ) {
+                        tip( '{{ _( "Updating in progress ..." ) }}', "info");
+                    } else {
+                        tip( result['reason'], "warning");
+                    }
+                },
+                error: function() {
+                    displayErrorMessage();
+                }
+            });
+        }
+
+        function getUpdateInfo() {
+            if (isShown) {
+                return;
+            }
+
+            var pageRequests = {};
+            pageRequests['cmd'] = 'get_info';
+
+            $.ajax({
+                type: 'GET',
+                url: '/update',
+                data: pageRequests,
+                dataType: 'JSON',
+                success: function(result) {
+                    var versionType = result['type'];
+                    switch ( versionType ) {
+                    case 'init':
+                        window.setTimeout(getUpdateInfo, 1000);
+                        break;
+                    case 'dont-check':
+                        stopUpdateCheck();
+                        break;
+                    default:
+                        version = result['version'];
+                        if ( versionType && version ) {
+                            switch ( versionType ) {
+                            case 'stable':
+                                popText = '{{ _( "Stable version" ) }} ' + version + ' {{ _( "is valid." ) }}';
+                                break;
+                            case 'test':
+                                popText = '{{ _( "Test version" ) }} ' + version + ' {{ _( "is valid." ) }}';
+                            }
+                            $('#update-message').text(popText);
+                            $('#update-notify').css('display', '');
+                            isShown = true;
+                        }
+                    }
+                }
+            });
+        }
+
+        $('#update-now').click(updateVersion);
+        $('#update-next').click(clearUpdateInfo);
+        $('#update-skip').click(skipUpdateVersion);
+        $('#update-notify-close').click(clearUpdateInfo);
+        clearNotify();
+        getUpdateInfo();
+        checkUpdateTimer = $.timer(getUpdateInfo, checkUpdateTimeout, true);
+    </script>
+    <script type="text/javascript">
+        //pop up notify on top of status web page.
+        function popup_notify(text,linkText,linkHref,open_in_newtab,bcolor)
+        {
+            var notify_area = document.getElementById("notify-area");
+            
+            //create new div for notify
+            var newdiv = notify_area.appendChild(document.createElement("div"));
+            newdiv.className = "popnotify";
+            if(bcolor != "")
+            {
+                newdiv.style.backgroundColor=bcolor;
+            }
+            
+            //in new div create span as notify text
+            var notify_text_span = newdiv.appendChild(document.createElement("span"));
+            //write the notify text in
+            notify_text_span.appendChild(document.createTextNode(text));
+            notify_text_span.className = "popnotify-text";
+            
+            //in new div create span as link
+            var notify_link_span = newdiv.appendChild(document.createElement("span"));
+            notify_link_span.className = "popnotify-text";
+            //in link span create link
+            var notify_link = notify_link_span.appendChild(document.createElement("a"));
+            if(linkHref)
+            {
+                //write link address in
+                notify_link.href = linkHref;
+            }
+            else
+                notify_link.href = "#"; //go nowhere
+            if(open_in_newtab)
+            {
+                notify_link.target = "_blank";
+            }
+            //write link text in
+            notify_link.appendChild(document.createTextNode(linkText));
+            
+            //create close notify button
+            var notify_close_btn = newdiv.appendChild(document.createElement("span"));
+            notify_close_btn.className = "popnotify-close-btn";
+            notify_close_btn.appendChild(document.createTextNode("×"));
+            notify_close_btn.style = "float:right; cursor: pointer;";
+            notify_close_btn.onclick = function()
+            {
+                //close this popup
+                notify_area.removeChild(this.parentNode);
+            }
+            //return the link object , can be used as button
+            return notify_link_span;
+        }
+        //Examples .  uncomment to see .
+        /*
+        var aaa = popup_notify("This is notify example. ","click text");
+        aaa.onclick = function() { alert('hello'); } 
+        popup_notify("This is notify example 2 . ", "","","", "yellow");
+        popup_notify("This is notify example 3 . ","Link text","whereDoWeGo",1,"#dddddd");
+        */
     </script>
 </body>
 </html>

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -148,6 +148,7 @@
         var checkUpdateTimeout = 600000;
         var checkUpdateTimer;
         var versionToUpdate;
+        var versionType;
 
         function displayErrorMessage() {
             tip('{{ _( "Unkown error occured. Please refresh the page and try again" ) }}', 'error');
@@ -237,6 +238,7 @@
             var pageRequests = {};
             pageRequests['cmd'] = 'set_config';
             pageRequests['skip_version'] = versionToUpdate;
+            pageRequests['skip_version_type'] = versionType;
 
             $.ajax({
                 type: 'GET',
@@ -295,7 +297,7 @@
                 data: pageRequests,
                 dataType: 'JSON',
                 success: function(result) {
-                    var versionType = result['type'];
+                    versionType = result['type'];
                     switch ( versionType ) {
                     case 'init':
                         window.setTimeout(startUpdateCheck, 1000);

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -334,7 +334,7 @@
 
                         if ( $('#upgrade-pull-icon').hasClass('icon-chevron-right') ){
                             var current_version = $('#current-version-no').html();
-                            if ( current_version == "" && $('.active a').attr('href') == '/?module=launcher&menu=config'){
+                            if ( current_version == "" ){
                                 $('#current-version-no').html(" ");
                                 // avoid check next time.
 

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -157,7 +157,11 @@
         function startUpdateCheck() {
             var pageRequests = {};
             pageRequests['cmd'] = 'start_check';
-            pageRequests['check_update'] = $('#check-update').val();
+            check_update = $('#check-update').val();
+            if ( !check_update ) {
+                check_update = '';
+            }
+            pageRequests['check_update'] = check_update;
 
             $.ajax({
                 type: 'GET',

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -183,6 +183,7 @@
         }
 
         function stopUpdateCheck() {
+            clearNotify();
             checkUpdateTimer.stop();
             var pageRequests = {};
             pageRequests['cmd'] = 'set_info';

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -65,7 +65,7 @@
                 <div class="span9">
                     <div id="update-notify">
                         <span id="update-notify-close">×</span>
-                        <span id="update-skip" class="update-notify-action">{{ _( "Do not remind me this version" ) }}</span>
+                        <span id="update-skip" class="update-notify-action">{{ _( "Do not remind me of this version" ) }}</span>
                         <span id="update-next" class="update-notify-action">{{ _( "Remind me next time" ) }}</span>
                         <span id="update-now" class="update-notify-action">{{ _( "Update now" ) }}</span>
                         <span id="update-message"></span>

--- a/code/default/launcher/web_ui/index.html
+++ b/code/default/launcher/web_ui/index.html
@@ -287,7 +287,7 @@
                     var versionType = result['type'];
                     switch ( versionType ) {
                     case 'init':
-                        window.setTimeout(getUpdateInfo, 1000);
+                        window.setTimeout(startUpdateCheck, 1000);
                         break;
                     case 'dont-check':
                         stopUpdateCheck();


### PR DESCRIPTION
需测试，有条件感兴趣的请帮忙。

为方便测试，可下载 [XX-Net-update-tip.zip](https://github.com/XX-net/XX-Net/files/1374175/XX-Net-update-tip.zip) 覆盖到 XX-Net 目录，会保持更新。

以下是设计目标：
>原来的升级设置选项：
>1. 不更新
>1. 自动升级到稳定版
>1. 自动升级到测试版
>
>修改为：
>1. 有稳定的新版时，通知（默认设置）
>1. 自动升级到稳定版
>1. 有测试的新版时，通知
>1. 自动升级到测试版
>1. 不更新
>
>通知后，有 4 个选择：
>1. 同意，立即更新
>1. 不再提示这个版本（需要记录下来本次提示的版本，下次检查到不提醒）
>1. 下次再提醒（什么也不做，下次启动会再提醒） #此处修改，非下次启动，改为 24 小时后
>1. 关闭，可以当作“下次再提醒我” 处理

增加：
显示下载进度，与之前的手动升级系统兼容。

 **重要改变：**
 子页面要使用 `$(document).ready` 时，不能直接调用，需要将函数放入主页面定义的 `documentReadyToRun` 数组，主页面会自动调用。

![p](https://user-images.githubusercontent.com/8470820/31313717-9afe9d02-ac1d-11e7-9402-b230a0b474f5.png)
