### PR TITLE
fix content_range error

### DIFF
--- a/code/default/gae_proxy/local/gae_handler.py
+++ b/code/default/gae_proxy/local/gae_handler.py
@@ -520,7 +520,7 @@ def handler(method, url, headers, body, wfile):
     content_length = int(response.headers.get('Content-Length', 0))
     content_range = response.headers.get('Content-Range', '')
     # content_range 分片时合并用到
-    if content_range:
+    if content_range and 'bytes */' not in content_range:
         start, end, length = tuple(int(x) for x in re.search(
             r'bytes (\d+)-(\d+)/(\d+)', content_range).group(1, 2, 3))
     else:


### PR DESCRIPTION
Except stack:Traceback (most recent call last): File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.9.6/smart_router/local/smart_route.py", line 297, in try_loop do_gae(sock, host, port, client_address, left_buf) File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.9.6/smart_router/local/smart_route.py", line 266, in do_gae req.do_METHOD() File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.9.6/gae_proxy/local/proxy_handler.py", line 223, in do_METHOD return self.do_AGENT() File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.9.6/gae_proxy/local/proxy_handler.py", line 271, in do_AGENT gae_handler.handler(self.command, self.path, request_headers, payload, self.wfile) File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.9.6/gae_proxy/local/gae_handler.py", line 525, in handler r'bytes (\d+)-(\d+)/(\d+)', content_range).group(1, 2, 3)) AttributeError: 'NoneType' object has no attribute 'group'


content_range :
bytes */439979