### PR TITLE
fix http2 recv fail

### DIFF
--- a/code/default/python27/1.0/lib/noarch/front_base/http2_connection.py
+++ b/code/default/python27/1.0/lib/noarch/front_base/http2_connection.py
@@ -308,7 +308,7 @@ class Http2Worker(HttpWorker):
             return
 
         # Parse the header. We can use the returned memoryview directly here.
-        frame, length = Frame.parse_frame_header(header)
+        frame, length = Frame.parse_frame_header(header.tobytes())
 
         if length > FRAME_MAX_ALLOWED_LEN:
             self.logger.error("%s Frame size exceeded on stream %d (received: %d, max: %d)",
@@ -317,7 +317,7 @@ class Http2Worker(HttpWorker):
 
         data = self._recv_payload(length)
         self.last_active_time = time.time()
-        self._consume_frame_payload(frame, data)
+        self._consume_frame_payload(frame, data.tobytes())
 
     def _recv_payload(self, length):
         if not length:


### PR DESCRIPTION
Feb 23 12:38:12.885 [cloudflare_front][ERROR] Except stack:Traceback (most recent call last):
  File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.10.4/python27/1.0/lib/noarch/front_base/http2_connection.py", line 205, in recv_loop
    self._consume_single_frame()
  File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.10.4/python27/1.0/lib/noarch/front_base/http2_connection.py", line 305, in _consume_single_frame
    frame, length = Frame.parse_frame_header(header)
  File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.10.4/python27/1.0/lib/noarch/hyper/packages/hyperframe/frame.py", line 75, in parse_frame_header
    fields = struct.unpack("!HBBBL", header)
error: unpack requires a string argument of length 9

Feb 23 11:42:30.462 [cloudflare_front][ERROR] Except stack:Traceback (most recent call last):
  File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.10.4/python27/1.0/lib/noarch/front_base/http2_connection.py", line 205, in recv_loop
    self._consume_single_frame()
  File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.10.4/python27/1.0/lib/noarch/front_base/http2_connection.py", line 328, in _consume_single_frame
    self._consume_frame_payload(frame, data)
  File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.10.4/python27/1.0/lib/noarch/front_base/http2_connection.py", line 351, in _consume_frame_payload
    frame.parse_body(data)
  File "/data/user/0/net.xndroid/files/xndroid_files/xxnet/code/3.10.4/python27/1.0/lib/noarch/hyper/packages/hyperframe/frame.py", line 331, in parse_body
    name, value = struct.unpack("!HL", data[i:i+6])
error: unpack requires a string argument of length 6