### PR TITLE
migrate from PyGTK to PyGObject (also GTK2 to GTK3)

### DIFF
--- a/code/default/launcher/start.py
+++ b/code/default/launcher/start.py
@@ -86,9 +86,9 @@ if "arm" in platform.machine() or "mips" in platform.machine() or "aarch64" in p
 elif sys.platform.startswith("linux"):
     def X_is_running():
         try:
-            import pygtk
-            pygtk.require('2.0')
-            import gtk
+            import gi
+            gi.require_version('Gtk', '3.0')
+            from gi.repository import Gtk as gtk
 
             from subprocess import Popen, PIPE
             p = Popen(["xset", "-q"], stdout=PIPE, stderr=PIPE)


### PR DESCRIPTION
之前XX-Net在Linux桌面所依赖的PyGTK很多年以前就不再维护了，其官网也建议使用PyGObject来取代它。
于是我创建了这个PR，从PyGTK迁移到了PyGObject，顺带地也将图形库的依赖从GTK2升级为GTK3。
当然，XX-Net的一些依赖也会改变（从pygtk, python-appindicator, python-notify简化为python-gobject, libappindicator和libnotify），如果PR被采纳，我会跟进更新Wiki页面。
最后，还修正了一个typo :-)