### PR TITLE
gtk_tray 优先使用 pygtk

### DIFF
--- a/code/default/launcher/gtk_tray.py
+++ b/code/default/launcher/gtk_tray.py
@@ -24,6 +24,13 @@ if 'XDG_CURRENT_DESKTOP' in os.environ:
         enable_appind = True
 
 try:
+    import pygtk
+    pygtk.require('2.0')
+    import gtk
+    import gtk.gdk as gdk
+    use_gi = False
+    xlog.info('Using PyGTK as the GUI Backend.')
+except:
     import gi
     gi.require_version('Gtk', '3.0')
     gi.require_version('Gdk', '3.0')
@@ -31,13 +38,6 @@ try:
     from gi.repository import Gdk as gdk
     use_gi = True
     xlog.info('Using PyGObject as the GUI Backend.')
-except:
-    import pygtk
-    pygtk.require('2.0')
-    import gtk
-    import gtk.gdk as gdk
-    use_gi = False
-    xlog.info('Using PyGTK as the GUI Backend.')
 
 gdk.threads_init()
 
@@ -93,6 +93,7 @@ class Gtk_tray():
             xlog.info('AppIndicator found and used.')
         else:
             self.trayicon = self.gtk_trayicon(logo_filename)
+            xlog.info('Gtk.StatusIcon used.')
 
     def appind_trayicon(self, logo_filename):
         trayicon = new_appindicator('XX-Net', 'indicator-messages', appind_category)

--- a/code/default/launcher/start.py
+++ b/code/default/launcher/start.py
@@ -116,7 +116,7 @@ elif sys.platform.startswith("linux"):
         except:
             return False
 
-    if X_is_running() and (has_gi() or has_pygtk()):
+    if X_is_running() and (has_pygtk() or has_gi()):
         from gtk_tray import sys_tray
     else:
         from non_tray import sys_tray


### PR DESCRIPTION
#9994 修改中，基于PyGObject的实现在某些系统上会导致设置页面打不开，原因未知，因此改回默认使用PyGTK。
fix #10046 fix #10080 fix #10112 fix #10113 fix #10193 