### PR TITLE
Add support for listen v6

### DIFF
--- a/code/default/gae_proxy/local/proxy.py
+++ b/code/default/gae_proxy/local/proxy.py
@@ -118,16 +118,21 @@ def main(args):
     CertUtil.init_ca()
 
     allow_remote = args.get("allow_remote", 0)
-    if allow_remote:
-        listen_ip = "0.0.0.0"
+
+    listen_ips = front.config.listen_ip
+    if isinstance(listen_ip, str):
+        listen_ips = [listen_ips]
     else:
-        listen_ip = front.config.listen_ip
+        listen_ips = list(listen_ips)
+    if allow_remote and ("0.0.0.0" not in listen_ips or "::" not in listen_ips):
+        listen_ips.append("0.0.0.0")
+    addresses = [(listen_ip, front.config.listen_port) for listen_ip in listen_ips]
 
     front.start()
     direct_front.start()
 
     proxy_server = simple_http_server.HTTPServer(
-        (listen_ip, front.config.listen_port), proxy_handler.GAEProxyHandler, logger=xlog)
+        addresses, proxy_handler.GAEProxyHandler, logger=xlog)
 
     ready = True  # checked by launcher.module_init
     

--- a/code/default/launcher/web_control.py
+++ b/code/default/launcher/web_control.py
@@ -690,17 +690,23 @@ def start(allow_remote=0):
     # should use config.yaml to bind ip
     if not allow_remote:
         allow_remote = config.get(["modules", "launcher", "allow_remote_connect"], 0)
+    host_ip = config.get(["modules", "launcher", "control_ip"], "127.0.0.1")
     host_port = config.get(["modules", "launcher", "control_port"], 8085)
 
     if allow_remote:
-        host_addr = "0.0.0.0"
         xlog.info("allow remote access WebUI")
+
+    if isinstance(host_ip, str):
+        listen_ips = [host_ip]
     else:
-        host_addr = "127.0.0.1"
+        listen_ips = list(host_ip)
+    if allow_remote and ("0.0.0.0" not in listen_ips or "::" not in listen_ips):
+        listen_ips.append("0.0.0.0")
+    addresses = [(listen_ip, host_port) for listen_ip in listen_ips]
 
     xlog.info("begin to start web control")
 
-    server = simple_http_server.HTTPServer((host_addr, host_port), Http_Handler, logger=xlog)
+    server = simple_http_server.HTTPServer(addresses, Http_Handler, logger=xlog)
     server.start()
 
     xlog.info("launcher web control started.")

--- a/code/default/smart_router/local/__init__.py
+++ b/code/default/smart_router/local/__init__.py
@@ -119,22 +119,31 @@ def run(args):
     g.dns_client = dns_server.DnsClient()
 
     allow_remote = args.get("allow_remote", 0)
-    if allow_remote:
-        listen_ip = "0.0.0.0"
+
+    listen_ips = g.config.proxy_bind_ip
+    if isinstance(listen_ip, str):
+        listen_ips = [listen_ips]
     else:
-        listen_ip = g.config.proxy_bind_ip
-    g.proxy_server = simple_http_server.HTTPServer((listen_ip, g.config.proxy_port),
+        listen_ips = list(listen_ips)
+    if allow_remote and ("0.0.0.0" not in listen_ips or "::" not in listen_ips):
+        listen_ips.append("0.0.0.0")
+    addresses = [(listen_ip, g.config.proxy_port) for listen_ip in listen_ips]
+
+    g.proxy_server = simple_http_server.HTTPServer(addresses,
                                                    proxy_handler.ProxyServer, logger=xlog)
     g.proxy_server.start()
     xlog.info("Proxy server listen:%s:%d.", listen_ip, g.config.proxy_port)
 
-    allow_remote = args.get("allow_remote", 0)
-    if allow_remote:
-        listen_ip = "0.0.0.0"
+    listen_ips = front.config.dns_bind_ip
+    if isinstance(listen_ip, str):
+        listen_ips = [listen_ips]
     else:
-        listen_ip = g.config.dns_bind_ip
+        listen_ips = list(listen_ips)
+    if allow_remote and ("0.0.0.0" not in listen_ips or "::" not in listen_ips):
+        listen_ips.append("0.0.0.0")
+
     g.dns_srv = dns_server.DnsServer(
-        bind_ip=listen_ip, port=g.config.dns_port,
+        bind_ip=listen_ips, port=g.config.dns_port,
         backup_port=g.config.dns_backup_port,
         ttl=g.config.dns_ttl)
     ready = True

--- a/code/default/smart_router/local/dns_server.py
+++ b/code/default/smart_router/local/dns_server.py
@@ -313,34 +313,46 @@ class DnsClient(object):
 
 class DnsServer(object):
     def __init__(self, bind_ip="127.0.0.1", port=53, backup_port=5353, ttl=24*3600):
-        self.bind_ip = bind_ip
+        self.sockets = []
+        self.running = False
+        if isinstance(bind_ip, str):
+            self.bind_ip = [bind_ip]
+        else:
+            # server can listen multi-port
+            self.bind_ip = bind_ip
         self.port = port
         self.backup_port = backup_port
         self.ttl = ttl
         self.th = None
-        self.bing_linsten()
+        self.init_socket()
 
-    def bing_linsten(self):
-        self.serverSock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    def init_socket(self):
+        for ip in self.bind_ip:
+            self.bing_linsten(ip)
+
+    def bing_linsten(self, bind_ip):
+        if ":" in addr[0]:
+            sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        else:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
-            self.serverSock.bind((self.bind_ip, self.port))
-            xlog.info("start DNS server at %s:%d", self.bind_ip, self.port)
+            sock.bind((bind_ip, self.port))
+            xlog.info("start DNS server at %s:%d", bind_ip, self.port)
             self.running = True
-            self.sockets = [self.serverSock]
+            self.sockets.append(sock)
             return
         except:
-            xlog.warn("bind DNS %s:%d fail", self.bind_ip, self.port)
+            xlog.warn("bind DNS %s:%d fail", bind_ip, self.port)
             pass
 
         try:
-            self.serverSock.bind((self.bind_ip, self.backup_port))
-            xlog.info("start DNS server at %s:%d", self.bind_ip, self.backup_port)
+            sock.bind((bind_ip, self.backup_port))
+            xlog.info("start DNS server at %s:%d", bind_ip, self.backup_port)
             self.running = True
-            self.sockets = [self.serverSock]
+            self.sockets.append(sock)
             return
         except Exception as e:
-            self.running = False
-            xlog.warn("bind DNS %s:%d fail", self.bind_ip, self.backup_port)
+            xlog.warn("bind DNS %s:%d fail", bind_ip, self.backup_port)
 
             if sys.platform.startswith("linux"):
                 xlog.warn("You can try: install libcap2-bin")
@@ -399,20 +411,20 @@ class DnsServer(object):
 
         return ips
 
-    def direct_query(self, request, client_addr):
+    def direct_query(self, rsock, request, client_addr):
         start_time = time.time()
         for server_ip in g.dns_client.dns_server.public_list:
             try:
                 a_pkt = request.send(server_ip, 53, tcp=True, timeout=1)
                 # a = DNSRecord.parse(a_pkt)
-                self.serverSock.sendto(a_pkt, client_addr)
+                rsock.sendto(a_pkt, client_addr)
                 return
             except:
                 if time.time() - start_time > 5:
                     xlog.warn("direct_query %s timeout", request)
                     break
 
-    def on_udp_query(self, req_data, addr):
+    def on_udp_query(self, rsock, req_data, addr):
         start_time = time.time()
         try:
             request = DNSRecord.parse(req_data)
@@ -428,7 +440,7 @@ class DnsServer(object):
             type = request.questions[0].qtype
             if type not in [1, 28]:
                 xlog.info("direct_query:%s type:%d", domain, type)
-                return self.direct_query(request, addr)
+                return self.direct_query(rsock, request, addr)
 
             xlog.debug("DNS query:%s type:%d from %s", domain, type, addr)
 
@@ -447,7 +459,7 @@ class DnsServer(object):
                     reply.add_answer(RR(domain, rtype=type, ttl=60, rdata=AAAA(ip)))
             res_data = reply.pack()
 
-            self.serverSock.sendto(res_data, addr)
+            rsock.sendto(res_data, addr)
             xlog.debug("query:%s type:%d from:%s, return ip num:%d cost:%d", domain, type, addr,
                        len(reply.rr), (time.time()-start_time)*1000)
         except Exception as e:
@@ -458,12 +470,9 @@ class DnsServer(object):
             r, w, e = select.select(self.sockets, [], [], 1)
             for rsock in r:
                 data, addr = rsock.recvfrom(1024)
-                threading.Thread(target=self.on_udp_query, args=(data, addr)).start()
+                threading.Thread(target=self.on_udp_query, args=(rsock, data, addr)).start()
 
-        self.serverSock.close()
-        self.sockets = []
         self.th = None
-        xlog.info("dns_server stop")
 
     def start(self):
         self.th = threading.Thread(target=self.server_forever)
@@ -473,6 +482,10 @@ class DnsServer(object):
         self.running = False
         while self.th:
             time.sleep(1)
+        for sock in self.sockets:
+            sock.close()
+        self.sockets = []
+        xlog.info("dns_server stop")
 
 
 if __name__ == '__main__':

--- a/code/default/x_tunnel/local/client.py
+++ b/code/default/x_tunnel/local/client.py
@@ -164,12 +164,17 @@ def main(args):
     g.session = proxy_session.ProxySession()
 
     allow_remote = args.get("allow_remote", 0)
-    if allow_remote:
-        listen_ip = "0.0.0.0"
-    else:
-        listen_ip = g.config.socks_host
 
-    g.socks5_server = simple_http_server.HTTPServer((listen_ip, g.config.socks_port), Socks5Server, logger=xlog)
+    listen_ips = g.config.socks_host
+    if isinstance(listen_ip, str):
+        listen_ips = [listen_ips]
+    else:
+        listen_ips = list(listen_ips)
+    if allow_remote and ("0.0.0.0" not in listen_ips or "::" not in listen_ips):
+        listen_ips.append("0.0.0.0")
+    addresses = [(listen_ip, g.config.socks_port) for listen_ip in listen_ips]
+
+    g.socks5_server = simple_http_server.HTTPServer(addresses, Socks5Server, logger=xlog)
     xlog.info("Socks5 server listen:%s:%d.", g.config.socks_host, g.config.socks_port)
 
     ready = True


### PR DESCRIPTION
#11641 
添加可监听多个 IP（包括 IPv6），并保持其余行为和旧版一致，需手动编辑配置文件。

#### 定义
```
IP := "任意有效 IP 或空白字符串"
IP 列表 := [IP, IP, ...]
IP 参数 := IP 或 IP 列表
```
#### web control
data/launcher/config.yaml
```yaml
modules:
  launcher: {control_ip: IP 参数}
```
#### gae proxy
data/gae_proxy/config.json
```yaml
{
  "listen_ip": IP 参数
}
```
#### x-tunnel
data/x_tunnel/client.json
```yaml
{
  "socks_host": IP 参数
}
```
#### smart route & dns sever
data/smart_router/config.json
```yaml
{
  "dns_bind_ip": IP 参数,
  "proxy_bind_ip": IP 参数
}
```