### PR TITLE
[FIX] double click "start.vbs" doesn't work if environments conflict

### DIFF
--- a/start.vbs
+++ b/start.vbs
@@ -61,4 +61,6 @@ strArgs = strExecutable & " " & quo & strCurrentPath & "\code\" & strVersion & "
 'WScript.Echo strArgs
 
 Set oShell = CreateObject ("Wscript.Shell")
+oShell.Environment("Process")("PYTHONPATH")=""
+oShell.Environment("Process")("PYTHONHOME")=""
 oShell.Run strArgs, isConsole(), false


### PR DESCRIPTION
[FIX] double click "start.vbs" doesn't work if environments conflict