### PR TITLE
明确代理模式为Http模式

### DIFF
--- a/code/default/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
+++ b/code/default/gae_proxy/lang/zh_CN/LC_MESSAGES/messages.po
@@ -441,7 +441,7 @@ msgid "System Proxy Status"
 msgstr "系统代理状态"
 
 msgid "Listening At"
-msgstr "代理监听"
+msgstr "HTTP代理监听"
 
 # msgid "PAC URL"
 # msgstr "PAC 自动代理地址"


### PR DESCRIPTION
昨天帮朋友配置时，错把代理记成了socks5代理，整了2个小时最后才发现应该是http代理，特此将127.0.0.1:8085的页面中代理明确写为http代理，避免再有人记错浪费大量时间。