### PR TITLE
disable gae commonname check

### DIFF
--- a/code/default/gae_proxy/local/config.py
+++ b/code/default/gae_proxy/local/config.py
@@ -208,7 +208,7 @@ lwIDAQAB
 -----END PUBLIC KEY-----
 '''
         ])
-        self.set_var("check_commonname", "Google")
+        #self.set_var("check_commonname", "Google")
         self.set_var("min_intermediate_CA", 2)
         self.set_var("support_http2", 1)
 


### PR DESCRIPTION
警告：
此补丁去除了对 GAE IP 的 commonname 检查，publickey 检查仍然工作。
请保持 pyOpenSSL 版本大于 16.0.0，不要使用旧版本！否则可能被中间人攻击。