### PR TITLE
add workflow:  notify_aur_upgrade

### DIFF
--- a/.github/workflows/notify_aur_upgrade.yml
+++ b/.github/workflows/notify_aur_upgrade.yml
@@ -1,0 +1,18 @@
+name: notify_aur_upgrade
+on:
+  push:
+
+jobs:
+  Notify:
+    name: Notify
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer 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"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/lisuke/PKGBUILD/actions/workflows/xx-net.yml/dispatches \
+            -d '{"ref":"master"}'


### PR DESCRIPTION
  I am a maintainer of [aur/xx-net repo](https://aur.archlinux.org/packages/xx-net). 

  Now, I am using github workflow to realize automatic upgrade.

  Send a workflow_dispatch request to a workflow of lisuke/PKGBUILD repo, notify that the workflow aur/xx-net can start upgrading.