### PR TITLE
修正 listen_ip 为 IPv6 地址时 simple_http_server 格式化失败

### DIFF
--- a/code/default/lib/noarch/simple_http_server.py
+++ b/code/default/lib/noarch/simple_http_server.py
@@ -625,7 +625,7 @@ class HTTPServer():
             return
 
         client_obj = self.handler(sock, address, self.args)
-        client_thread = threading.Thread(target=client_obj.handle, name="handle_%s:%d" % address)
+        client_thread = threading.Thread(target=client_obj.handle, name="handle:{}".format(address))
         client_thread.start()
 
     def check_listen_port(self, ip, port):


### PR DESCRIPTION
当 listen_ip 为 IPv6 地址，比如 ::1 时，simple_http_server 回报错误：

```
2024-01-21 05:48:21.953 - [ERROR] serve except:TypeError('not all arguments converted during string formatting')
2024-01-21 05:48:21.956 - [ERROR] Except stack:Traceback (most recent call last): File "/[redacted]/XX-Net/code/default/lib/noarch/simple_http_server.py", line 611, in serve_forever self.process_connect(sock, address) File "/[redacted]/XX-Net/code/default/lib/noarch/simple_http_server.py", line 628, in process_connect client_thread = threading.Thread(target=client_obj.handle, name="handle_undefined:%d" % address) ~~~~~~~~~~~~~~~^~~~~~~~~ TypeError: not all arguments converted during string formatting
```